### PR TITLE
Generate GAQL by referencing examples from query cookbook

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ dirs = "4.0"
 figment = { version = "0.10", features = ["toml", "env"] }
 flexi_logger = { version = "0.22", features = ["compress"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
-googleads-rs = { version = "0.9.0" }
-#googleads-rs = { version = "0.9.0", path = "../googleads-rs" }
+# googleads-rs = { version = "0.9.0" }
+googleads-rs = { version = "0.9.1", path = "../googleads-rs" }
 itertools = "0.10"
 log = "0.4"
 polars = { version = "0.42", features = ["lazy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mcc-gaql"
 description = "Execute GAQL across MCC child accounts."
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Michael S. Huang <mhuang74@gmail.com>"]
 edition = "2021"
 
@@ -30,3 +30,6 @@ toml = "0.5"
 tonic = { version = "0.8", features = ["tls", "tls-roots"] }
 serde_json = "1.0"
 yup-oauth2 = "6.7"
+rig-core = "0.7.0"
+rig-lancedb = "0.2.3"
+lancedb = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ dirs = "4.0"
 figment = { version = "0.10", features = ["toml", "env"] }
 flexi_logger = { version = "0.22", features = ["compress"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
-# googleads-rs = { version = "0.9.0" }
-googleads-rs = { version = "0.9.1", path = "../googleads-rs" }
+googleads-rs = { version = "0.9.1" }
+# googleads-rs = { version = "0.9.1", path = "../googleads-rs" }
 itertools = "0.10"
 log = "0.4"
 polars = { version = "0.42", features = ["lazy"] }
@@ -31,5 +31,5 @@ tonic = { version = "0.8", features = ["tls", "tls-roots"] }
 serde_json = "1.0"
 yup-oauth2 = "6.7"
 rig-core = "0.7.0"
-rig-lancedb = "0.2.3"
-lancedb = "0.15.0"
+# rig-lancedb = "0.2.3"
+# lancedb = "0.15.0"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Command line tool to execute Google Ads GAQL queries across MCC child accounts. 
 * Query for Asset-based Ad Extensions traffic to see which accounts use them
 * Look at adoption trend of Performance Max Campaigns across customer base
 
+## Example commands
+
+```
+MCC_GAQL_LOG_LEVEL="info,mcc_gaql=debug" mcc-gaql -q recent_campaign_changes -o all_recent_changes.csv
+MCC_GAQL_LOG_LEVEL="info,mcc_gaql=debug" mcc-gaql -n "campaign changes from last 14 days with current campaign status and bidding strategy" -o foo.csv
+MCC_GAQL_LOG_LEVEL="info,mcc_gaql=debug" mcc-gaql -n "recent changes for AD but don't include AD ID"
+```
+
 ## Alternatives
 
 * [gaql-cli](https://github.com/getyourguide/gaql-cli)

--- a/resources/query_cookbook.toml
+++ b/resources/query_cookbook.toml
@@ -8,85 +8,107 @@
 #
 # Naming Convention = <grain>_with_<description>, e.g. accounts_with_traffic_last_week
 #
+# FORMAT
 #
-##
+# [query_name_using_snake_case]
+# description = """
+# Provide a description of query
+# """
+# query = """
+# actual GAQL query
+# """
+#
 
-
-# Account IDs Accessible and Trafficking
-account_ids_with_access_and_traffic_last_week = """
-	SELECT 
-	  customer.id
-	FROM customer 
-	WHERE 
-	  segments.date during LAST_7_DAYS
-	  AND metrics.clicks > 1
+[account_ids_with_access_and_traffic_last_week]
+description = """
+Account IDs Accessible and Trafficking
+"""
+query = """
+SELECT 
+	customer.id
+FROM customer 
+WHERE 
+	segments.date during LAST_7_DAYS
+	AND metrics.clicks > 1
 """
 
-# Accounts with Traffic Last Week
-accounts_with_traffic_last_week = """
-	SELECT 
-	  customer.id, 
-	  customer.descriptive_name, 
-	  metrics.impressions, 
-	  metrics.clicks, 
-	  metrics.cost_micros,
-	  customer.currency_code 
-	FROM customer 
-	WHERE 
-	  segments.date during LAST_7_DAYS
-	  AND metrics.impressions > 1
+[accounts_with_traffic_last_week]
+description = """
+Accounts with Traffic Last Week
+"""
+query = """
+SELECT 
+	customer.id, 
+	customer.descriptive_name, 
+	metrics.impressions, 
+	metrics.clicks, 
+	metrics.cost_micros,
+	customer.currency_code 
+FROM customer 
+WHERE 
+	segments.date during LAST_7_DAYS
+	AND metrics.impressions > 1
 """
 
-# Top Keywords
-keywords_with_top_traffic_last_week = """
-	SELECT
-	  customer.id,
-	  customer.descriptive_name,
-	  campaign.id,
-	  campaign.name,
-	  campaign.advertising_channel_type,
-	  ad_group.id,
-	  ad_group.name,
-	  ad_group.type,
-	  ad_group_criterion.criterion_id,
-	  ad_group_criterion.keyword.text,
-	  metrics.impressions,
-	  metrics.clicks,
-	  metrics.cost_micros,
-	  customer.currency_code 
-	FROM keyword_view
-	WHERE
-	  segments.date DURING LAST_7_DAYS
-	  and metrics.clicks > 10000
-	ORDER BY
-	  metrics.clicks DESC
-	LIMIT 10
+[keywords_with_top_traffic_last_week]
+description = """
+Top Keywords
+"""
+query = """
+SELECT
+	customer.id,
+	customer.descriptive_name,
+	campaign.id,
+	campaign.name,
+	campaign.advertising_channel_type,
+	ad_group.id,
+	ad_group.name,
+	ad_group.type,
+	ad_group_criterion.criterion_id,
+	ad_group_criterion.keyword.text,
+	metrics.impressions,
+	metrics.clicks,
+	metrics.cost_micros,
+	customer.currency_code 
+FROM keyword_view
+WHERE
+	segments.date DURING LAST_7_DAYS
+	and metrics.clicks > 10000
+ORDER BY
+	metrics.clicks DESC
+LIMIT 10
 """
 
-# Accounts with Performance Max Campaigns
-accounts_with_perf_max_campaigns_last_week = """
-	SELECT 
-	  customer.id, 
-	  customer.descriptive_name, 
-	  campaign.id, 
-	  campaign.advertising_channel_type, 
-	  campaign.name, 
-	  metrics.impressions, 
-	  metrics.clicks, 
-	  metrics.cost_micros,
-	  customer.currency_code 
-	FROM campaign 
-	WHERE 
-	  segments.date DURING LAST_7_DAYS 
-	  AND campaign.advertising_channel_type IN ('PERFORMANCE_MAX') 
-	  AND metrics.clicks > 100
-	ORDER BY 
-	  metrics.clicks DESC 
-	LIMIT 1
+[accounts_with_perf_max_campaigns_last_week]
+description = """
+Accounts with Performance Max Campaigns
+"""
+query = """
+SELECT 
+  customer.id, 
+  customer.descriptive_name, 
+  campaign.id, 
+  campaign.advertising_channel_type, 
+  campaign.name, 
+  metrics.impressions, 
+  metrics.clicks, 
+  metrics.cost_micros,
+  customer.currency_code 
+FROM campaign 
+WHERE 
+  segments.date DURING LAST_7_DAYS 
+  AND campaign.advertising_channel_type IN ('PERFORMANCE_MAX') 
+  AND metrics.clicks > 100
+ORDER BY 
+  metrics.clicks DESC 
+LIMIT 1
 """
 
-# Accounts with Smart Campaigns
-accounts_with_smart_campaigns_last_week = """
+[accounts_with_smart_campaigns_last_week]
+description = """
+Accounts with Smart Campaigns
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name, 
@@ -107,8 +129,11 @@ accounts_with_smart_campaigns_last_week = """
 	LIMIT 1
 """
 
-# Accounts with Local Campaigns
-accounts_with_local_campaigns_last_week = """
+[accounts_with_local_campaigns_last_week]
+description = """
+Accounts with Local Campaigns
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name, 
@@ -129,8 +154,11 @@ accounts_with_local_campaigns_last_week = """
 	LIMIT 1
 """
 
-# Accounts with Shopping Campaigns
-accounts_with_shopping_campaigns_last_week = """
+[accounts_with_shopping_campaigns_last_week]
+description = """
+Accounts with Shopping Campaigns
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name, 
@@ -151,8 +179,11 @@ accounts_with_shopping_campaigns_last_week = """
 	LIMIT 1
 """
 
-# Accounts with Multi-Channel Campaigns
-accounts_with_multichannel_campaigns_last_week = """
+[accounts_with_multichannel_campaigns_last_week]
+description = """
+Accounts with Multi-Channel Campaigns
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name, 
@@ -174,8 +205,11 @@ accounts_with_multichannel_campaigns_last_week = """
 """
 
 
-# Accounts with Asset-based Sitelink Ext
-accounts_with_asset_sitelink_last_week = """
+[accounts_with_asset_sitelink_last_week]
+description = """
+Accounts with Asset-based Sitelink Ext
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name, 
@@ -197,8 +231,11 @@ accounts_with_asset_sitelink_last_week = """
 	LIMIT 1
 """
 
-# Accounts with Asset-based Call Ext
-accounts_with_asset_call_last_week = """
+[accounts_with_asset_call_last_week]
+description = """
+Accounts with Asset-based Call Ext
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name, 
@@ -220,8 +257,11 @@ accounts_with_asset_call_last_week = """
 	LIMIT 1
 """
 
-# Accounts with Asset-based Callout Ext
-accounts_with_asset_callout_last_week = """
+[accounts_with_asset_callout_last_week]
+description = """
+Accounts with Asset-based Callout Ext
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name, 
@@ -243,8 +283,11 @@ accounts_with_asset_callout_last_week = """
 	LIMIT 1
 """
 
-# Accounts with Asset-based App Ext
-accounts_with_asset_app_last_week = """
+[accounts_with_asset_app_last_week]
+description = """
+Accounts with Asset-based App Ext
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name, 
@@ -266,8 +309,11 @@ accounts_with_asset_app_last_week = """
 	LIMIT 1
 """
 
-# Last 30-day Traffic from Performance Max Campaigns
-perf_max_campaigns_with_traffic_last_30_days = """
+[perf_max_campaigns_with_traffic_last_30_days]
+description = """
+Last 30-day Traffic from Performance Max Campaigns
+"""
+query = """
 	SELECT 
 	  campaign.id, 
 	  segments.date,
@@ -284,8 +330,11 @@ perf_max_campaigns_with_traffic_last_30_days = """
 	  segments.date, campaign.id
 """
 
-# YTD Traffic from asset_field_type_view resource
-asset_fields_with_traffic_ytd = """
+[asset_fields_with_traffic_ytd]
+description = """
+YTD Traffic from asset_field_type_view resource
+"""
+query = """
 	SELECT 
 	  asset_field_type_view.field_type, 
 	  segments.date,
@@ -301,8 +350,11 @@ asset_fields_with_traffic_ytd = """
 	  asset_field_type_view.field_type, segments.date
 """
 
-# YTD Trafic from extension_feed_item resource
-extension_feed_items_with_traffic_ytd = """
+[extension_feed_items_with_traffic_ytd]
+description = """
+YTD Trafic from extension_feed_item resource
+"""
+query = """
 	SELECT
 	  extension_feed_item.extension_type,
 	  segments.date,
@@ -318,8 +370,11 @@ extension_feed_items_with_traffic_ytd = """
 	  extension_feed_item.extension_type, segments.date
 """
 
-# YTD Trafic from feed_placeholder_view resource
-feed_placeholders_with_traffic_ytd = """
+[feed_placeholders_with_traffic_ytd]
+description = """
+YTD Trafic from feed_placeholder_view resource
+"""
+query = """
 	SELECT
 	  feed_placeholder_view.placeholder_type,
 	  segments.date,
@@ -335,8 +390,11 @@ feed_placeholders_with_traffic_ytd = """
 	  feed_placeholder_view.placeholder_type, segments.date
 """
 
-# Top Spending Smart Bidding Campaigns
-campaigns_with_smart_bidding_by_spend = """
+[campaigns_with_smart_bidding_by_spend]
+description = """
+Top Spending Smart Bidding Campaigns
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name,
@@ -354,7 +412,7 @@ campaigns_with_smart_bidding_by_spend = """
  	  metrics.conversions_value
 	FROM campaign
 	WHERE
-	  campaign.bidding_strategy_type IN ('MAXIMIZE_CONVERSIONS', 'MAXIMIZE_CONVERSION_VALUE', 'TARGET_CPA', 'TARGET_ROAS') 
+	  campaign.bidding_strategy_type IN ('MAXIMIZE_CLICKS', 'MAXIMIZE_CONVERSIONS', 'MAXIMIZE_CONVERSION_VALUE', 'TARGET_CPA', 'TARGET_ROAS', 'TARGET_SPEND') 
 	  AND campaign.status IN ('ENABLED') 
 	  AND segments.date DURING LAST_7_DAYS 
 	  AND metrics.cost_micros > 1000000000
@@ -362,8 +420,11 @@ campaigns_with_smart_bidding_by_spend = """
 	LIMIT 25
 """
 
-# Performance of all Shopping Campaigns
-campaigns_shopping_campaign_performance = """
+[campaigns_shopping_campaign_performance]
+description = """
+Performance of all Shopping Campaigns
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name,
@@ -388,8 +449,11 @@ campaigns_shopping_campaign_performance = """
 	ORDER by metrics.cost_micros DESC
 """
 
-# Search Term Top CPA for Smart Campaigns
-smart_campaign_search_terms_with_top_spend = """
+[smart_campaign_search_terms_with_top_spend]
+description = """
+Search Term Top CPA for Smart Campaigns
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name, 
@@ -411,8 +475,11 @@ smart_campaign_search_terms_with_top_spend = """
 	LIMIT 100
 """
 
-# Search Terms with Clicks
-all_search_terms_with_clicks = """
+[all_search_terms_with_clicks]
+description = """
+Search Terms with Clicks
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name,
@@ -436,8 +503,11 @@ all_search_terms_with_clicks = """
 	  metrics.cost_micros desc
 """
 
-# Search Term Top CPA
-search_terms_with_top_cpa = """
+[search_terms_with_top_cpa]
+description = """
+Search Term Top CPA
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name,
@@ -463,8 +533,11 @@ search_terms_with_top_cpa = """
 	LIMIT 50 
 """
 
-# Search Term Low ROAS
-search_terms_with_low_roas = """
+[search_terms_with_low_roas]
+description = """
+Search Term Low ROAS
+"""
+query = """
 	SELECT 
 	  customer.id, 
 	  customer.descriptive_name,
@@ -490,8 +563,11 @@ search_terms_with_low_roas = """
 	LIMIT 50 
 """
 
-# locations by
-locations_with_highest_revenue_per_conversion = """
+[locations_with_highest_revenue_per_conversion]
+description = """
+top locations by revenue per conversion
+"""
+query = """
 	SELECT 
 		customer.id, 
 		customer.descriptive_name, 
@@ -520,8 +596,11 @@ locations_with_highest_revenue_per_conversion = """
 	LIMIT 1000
 """
 
-# Asset performance of Responsive Search Ads
-asset_performance_rsa = """
+[asset_performance_rsa]
+description = """
+Asset performance of Responsive Search Ads
+"""
+query = """
 SELECT 
   customer.id, 
   customer.descriptive_name, 
@@ -552,8 +631,11 @@ ORDER BY
 LIMIT 1000 
 """
 
-# investigate RSA and drill down on single adgroup for Nordstrom account
-asset_performance_rsa_nordstrom_drilldown = """
+[asset_performance_rsa_nordstrom_drilldown]
+description = """
+investigate RSA and drill down on single adgroup for Nordstrom account
+"""
+query = """
 SELECT 
   customer.id, 
   customer.descriptive_name, 
@@ -586,9 +668,11 @@ ORDER BY
 LIMIT 1000 
 """
 
-
-# investigate RSA assets and drill down on single adgroup for Nordstrom account
-asset_performance_rsa_assets_nordstrom_drilldown = """
+[asset_performance_rsa_assets_nordstrom_drilldown]
+description = """
+investigate RSA assets and drill down on single adgroup for Nordstrom account
+"""
+query = """
 SELECT 
   customer.id, 
   campaign.id, 
@@ -614,4 +698,54 @@ ORDER BY
   ad_group_ad.ad.id, 
   metrics.impressions DESC
 LIMIT 1000 
+"""
+
+[recent_campaign_changes]
+description = """
+recent campaign changes with user, changed fields, and datetime of change event
+"""
+query = """
+SELECT
+  customer.id,
+  customer.descriptive_name,
+  campaign.id,
+  change_event.change_date_time,
+  change_event.client_type,
+  change_event.change_resource_type,
+  change_event.changed_fields,
+  change_event.user_email,
+  campaign.name
+FROM
+  change_event
+WHERE
+  change_event.change_date_time DURING LAST_14_DAYS
+  AND change_event.change_resource_type IN ('CAMPAIGN')
+ORDER BY
+  change_event.change_date_time DESC
+LIMIT 100
+"""
+
+[recent_changes]
+description = """
+recent changes across common objects like campaign, adgroup, ad, keywords, budgets, etc. return with changed object type, fields, user, changed fields, and datetime of change event
+"""
+query = """
+SELECT
+  customer.id,
+  customer.descriptive_name,
+  campaign.id,
+  change_event.change_date_time,
+  change_event.client_type,
+  change_event.change_resource_type,
+  change_event.changed_fields,
+  change_event.user_email,
+  campaign.name
+FROM
+  change_event
+WHERE
+  change_event.change_date_time DURING LAST_14_DAYS
+  AND change_event.change_resource_type IN ('CAMPAIGN', 'AD_GROUP', 'AD_GROUP_AD', 'AD', 'AD_GROUP_CRITERION', 'CAMPAIGN_BUDGET')
+ORDER BY
+  change_event.change_date_time DESC
+LIMIT 100
 """

--- a/resources/query_cookbook.toml
+++ b/resources/query_cookbook.toml
@@ -519,3 +519,69 @@ locations_with_highest_revenue_per_conversion = """
 	  metrics.value_per_conversion desc, metrics.conversions desc
 	LIMIT 1000
 """
+
+# Asset performance of Responsive Search Ads
+asset_performance_rsa = """
+SELECT 
+  customer.id, 
+  customer.descriptive_name, 
+  campaign.id, 
+  campaign.name, 
+  campaign.advertising_channel_type, 
+  ad_group.id, 
+  ad_group.name, 
+  ad_group.type,
+  ad_group_ad.ad.id,
+  ad_group_ad.ad.responsive_search_ad.headlines, 
+  ad_group_ad.ad.responsive_search_ad.descriptions, 
+  ad_group_ad.ad.responsive_search_ad.path1, 
+  ad_group_ad.ad.responsive_search_ad.path2, 
+  metrics.impressions, 
+  metrics.clicks, 
+  metrics.ctr, 
+  metrics.cost_micros, 
+  metrics.average_cpc 
+FROM ad_group_ad 
+WHERE 
+  ad_group_ad.ad.type IN ('RESPONSIVE_SEARCH_AD') 
+  AND segments.date DURING LAST_30_DAYS 
+ORDER BY 
+  campaign.name, 
+  ad_group.name, 
+  metrics.ctr DESC 
+LIMIT 1000 
+"""
+
+# investigate RSA and drill down on single adgroup for Nordstrom account
+asset_performance_rsa_nordstrom_drilldown = """
+SELECT 
+  customer.id, 
+  customer.descriptive_name, 
+  campaign.id, 
+  campaign.name, 
+  campaign.advertising_channel_type, 
+  ad_group.id, 
+  ad_group.name, 
+  ad_group.type, 
+  ad_group_ad.ad.id,
+  ad_group_ad.ad.responsive_search_ad.headlines, 
+  ad_group_ad.ad.responsive_search_ad.descriptions, 
+  ad_group_ad.ad.responsive_search_ad.path1, 
+  ad_group_ad.ad.responsive_search_ad.path2, 
+  metrics.impressions, 
+  metrics.clicks, 
+  metrics.ctr, 
+  metrics.cost_micros, 
+  metrics.average_cpc 
+FROM ad_group_ad 
+WHERE 
+  ad_group_ad.ad.type IN ('RESPONSIVE_SEARCH_AD') 
+  AND segments.date DURING LAST_30_DAYS 
+  AND ad_group.id IN (98163443460)
+  AND campaign.id IN (9533454454)
+ORDER BY 
+  campaign.name, 
+  ad_group.name, 
+  metrics.ctr DESC 
+LIMIT 1000 
+"""

--- a/resources/query_cookbook.toml
+++ b/resources/query_cookbook.toml
@@ -585,3 +585,33 @@ ORDER BY
   metrics.ctr DESC 
 LIMIT 1000 
 """
+
+
+# investigate RSA assets and drill down on single adgroup for Nordstrom account
+asset_performance_rsa_assets_nordstrom_drilldown = """
+SELECT 
+  customer.id, 
+  campaign.id, 
+  ad_group.id, 
+  ad_group_ad.ad.id, 
+  ad_group_ad_asset_view.asset, 
+  ad_group_ad_asset_view.performance_label,
+  ad_group_ad_asset_view.field_type, 
+  ad_group_ad_asset_view.pinned_field, 
+  metrics.impressions,
+  metrics.clicks, 
+  metrics.ctr,
+  metrics.cost_micros
+FROM ad_group_ad_asset_view 
+WHERE 
+  ad_group_ad.ad.type IN ('RESPONSIVE_SEARCH_AD') 
+  AND segments.date DURING LAST_30_DAYS 
+  AND ad_group.id IN (98163443460)
+  AND campaign.id IN (9533454454)
+ORDER BY 
+  campaign.name, 
+  ad_group.name,
+  ad_group_ad.ad.id, 
+  metrics.impressions DESC
+LIMIT 1000 
+"""

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,6 +8,21 @@ use std::io::{self, Read};
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
 pub struct Cli {
+    /// Google Ads GAQL query to run
+    pub gaql_query: Option<String>,
+
+    /// Load named query from file
+    #[clap(short = 'q', long)]
+    pub stored_query: Option<String>,
+
+    /// Use natural language prompt instead of GAQL; prompt is converted to GAQL via LLM
+    #[clap(short = 'n', long)]
+    pub natural_language: bool,
+
+    /// GAQL output filename
+    #[clap(short, long)]
+    pub output: Option<String>,
+
     /// Query using default MCC and Child CustomerIDs file specified for this profile
     #[clap(short, long)]
     pub profile: Option<String>,
@@ -15,13 +30,6 @@ pub struct Cli {
     /// Apply query to a single CustomerID. Or use with `--all-linked-child-accounts` to query all child accounts.
     #[clap(short, long)]
     pub customer_id: Option<String>,
-
-    /// Load named query from file
-    #[clap(short = 'q', long)]
-    pub stored_query: Option<String>,
-
-    /// Google Ads GAQL query to run
-    pub gaql_query: Option<String>,
 
     /// List all child accounts under MCC
     #[clap(short, long)]
@@ -46,10 +54,6 @@ pub struct Cli {
     /// Sort by columns
     #[clap(long, multiple_occurrences(true))]
     pub sortby: Vec<String>,
-
-    /// GAQL output filename
-    #[clap(short, long)]
-    pub output: Option<String>,
 }
 
 pub fn parse() -> Cli {
@@ -57,7 +61,9 @@ pub fn parse() -> Cli {
 
     if cli.stored_query.is_none() && cli.gaql_query.is_none() && !cli.list_child_accounts {
         let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer).expect("Failed to read from stdin");
+        io::stdin()
+            .read_to_string(&mut buffer)
+            .expect("Failed to read from stdin");
         if !buffer.trim().is_empty() {
             cli.gaql_query = Some(buffer);
         }

--- a/src/googleads.rs
+++ b/src/googleads.rs
@@ -15,9 +15,9 @@ use yup_oauth2::{
     AccessToken, ApplicationSecret, InstalledFlowAuthenticator, InstalledFlowReturnMethod,
 };
 
+use googleads_rs::google::ads::googleads::v18::resources::GoogleAdsField;
 use googleads_rs::google::ads::googleads::v18::services::google_ads_field_service_client::GoogleAdsFieldServiceClient;
 use googleads_rs::google::ads::googleads::v18::services::google_ads_service_client::GoogleAdsServiceClient;
-use googleads_rs::google::ads::googleads::v18::resources::GoogleAdsField;
 use googleads_rs::google::ads::googleads::v18::services::{
     GoogleAdsRow, SearchGoogleAdsFieldsRequest, SearchGoogleAdsFieldsResponse,
     SearchGoogleAdsStreamRequest, SearchGoogleAdsStreamResponse,
@@ -76,7 +76,7 @@ const GOOGLE_ADS_METRICS_INTEGER_FIELDS: &[&str] = &[
     "organic_impressions",
     "organic_queries",
     "video_views",
-    "view_through_conversions"
+    "view_through_conversions",
 ];
 
 #[derive(Clone)]
@@ -218,7 +218,8 @@ pub async fn gaql_query_with_client(
                             // go through all columns specified in query, pull out string value, and insert into columns
                             for i in 0..headers.as_ref().unwrap().len() {
                                 let path = &headers.as_ref().unwrap()[i];
-                                let string_val: String = row.get(path).trim_matches('"').to_string();
+                                let string_val: String =
+                                    row.get(path).trim_matches('"').to_string();
                                 match columns.get_mut(i) {
                                     Some(v) => {
                                         v.push(string_val);
@@ -249,7 +250,10 @@ pub async fn gaql_query_with_client(
             if let Some(headers_vec) = headers {
                 for (i, header) in headers_vec.iter().enumerate() {
                     if header.starts_with("metrics") {
-                        if GOOGLE_ADS_METRICS_INTEGER_FIELDS.iter().any(|f| f==header) {
+                        if GOOGLE_ADS_METRICS_INTEGER_FIELDS
+                            .iter()
+                            .any(|f| f == header)
+                        {
                             let v: Vec<u64> = columns
                                 .get(i)
                                 .unwrap()
@@ -319,7 +323,13 @@ pub async fn fields_query(api_context: GoogleAdsAPIAccess, query: &str) {
     let mut stdout = async_std::io::stdout();
     for r in response.results {
         let row: GoogleAdsField = r;
-        let val = format!("{}\t{:?}\t{:?}\t{}\n", row.name, row.data_type(), row.category(), row.resource_name);
+        let val = format!(
+            "{}\t{:?}\t{:?}\t{}\n",
+            row.name,
+            row.data_type(),
+            row.category(),
+            row.resource_name
+        );
         stdout.write_all(val.as_bytes()).await.unwrap();
     }
 }

--- a/src/prompt2gaql.rs
+++ b/src/prompt2gaql.rs
@@ -1,172 +1,72 @@
-use std::{env, vec};
+use std::vec;
 
 use rig::{
+    agent::Agent,
     completion::{Completion, Prompt},
     embeddings::{embed::Embed, EmbedError, EmbeddingsBuilder, TextEmbedder},
-    providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
+    providers::openai::{Client, CompletionModel, TEXT_EMBEDDING_ADA_002, GPT_4O_MINI},
     vector_store::in_memory_store::InMemoryVectorStore,
 };
-use serde::Serialize;
 
-// Data to be RAGged.
-// A vector search needs to be performed on the `definitions` field, so we derive the `Embed` trait for `WordDefinition`
-// and tag that field with `#[embed]`.
-#[derive(Serialize, Clone, Debug, Eq, PartialEq, Default)]
-struct ExampleQuery {
-    id: String,
-    description: String,
-    query: String,
-}
+use crate::util::QueryEntry;
 
-impl Embed for ExampleQuery {
+// use description field from QueryEntry for embedding
+impl Embed for QueryEntry {
     fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError> {
         embedder.embed(self.description.clone());
         Ok(())
     }
 }
 
-pub async fn convert_to_gaql(prompt: &str) -> Result<String, anyhow::Error> {
-    // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+struct RAGAgent {
+    agent: Agent<CompletionModel>,
+}
 
-    let embedding_model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
+impl RAGAgent {
+    pub async fn init(openai_api_key: &str, query_cookbook: Vec<QueryEntry>) -> Result<Self, anyhow::Error> {
+        let client = Client::new(openai_api_key);
+        let embedding_model = client.embedding_model(TEXT_EMBEDDING_ADA_002);
 
-    // Generate embeddings for the definitions of all the documents using the specified embedding model.
-    let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
-        .documents(vec![
-            ExampleQuery {
-                id: "query0".to_string(),
-                description: "Performance of Shopping Campaigns for past 30 days".to_string(),
-                query: r#"
-SELECT 
-    customer.id, 
-    customer.descriptive_name,
-    campaign.id, 
-    campaign.name,
-    campaign.advertising_channel_type,
-    campaign.bidding_strategy_type,
-    campaign_budget.amount_micros,
-    metrics.average_cpc,
-    metrics.clicks, 
-    metrics.cost_micros,
-    customer.currency_code,
-    metrics.conversions,
-    metrics.cost_per_conversion,
-    metrics.conversions_value
-FROM campaign
-WHERE
-    campaign.advertising_channel_type IN ('SHOPPING') 
-    AND campaign.status IN ('ENABLED') 
-    AND segments.date DURING LAST_30_DAYS 
-    AND metrics.cost_micros > 100000000
-ORDER by metrics.cost_micros DESC
-                "#.to_string(),
-            },
-            ExampleQuery {
-                id: "query1".to_string(),
-                description: "Performance of Performance Max Campaigns for past 30 days".to_string(),
-                query: r#"
-SELECT 
-    campaign.id, 
-    segments.date,
-    metrics.impressions, 
-    metrics.clicks, 
-    metrics.cost_micros,
-    customer.currency_code 
-FROM campaign 
-WHERE 
-    segments.date DURING LAST_30_DAYS 
-    AND campaign.advertising_channel_type IN ('PERFORMANCE_MAX')
-    AND metrics.impressions > 1 
-ORDER BY 
-    segments.date, campaign.id
-                "#.to_string(),
-            },
-        ExampleQuery {
-                id: "query2".to_string(),
-                description: "Top Spending Smart Bidding Campaigns from past 7 days".to_string(),
-                query: r#"
-SELECT 
-    customer.id, 
-    customer.descriptive_name,
-    customer.currency_code,
-    campaign.id, 
-    campaign.name,
-    campaign.advertising_channel_type,
-    campaign.bidding_strategy_type,
-    campaign_budget.amount_micros,
-    metrics.average_cpc,
-    metrics.clicks, 
-    metrics.cost_micros,
-    metrics.conversions,
-    metrics.cost_per_conversion,
-    metrics.conversions_value
-FROM campaign
-WHERE
-    campaign.bidding_strategy_type IN ('MAXIMIZE_CONVERSIONS', 'MAXIMIZE_CONVERSION_VALUE', 'TARGET_CPA', 'TARGET_ROAS') 
-    AND campaign.status IN ('ENABLED') 
-    AND segments.date DURING LAST_7_DAYS 
-    AND metrics.cost_micros > 1000000000
-ORDER by metrics.cost_micros DESC
-LIMIT 25
-                "#.to_string(),
-            },
-            ExampleQuery {
-                id: "query3".to_string(),
-                description: "Top Keywords from last week".to_string(),
-                query: r#"
-SELECT
-    customer.id,
-    customer.descriptive_name,
-    campaign.id,
-    campaign.name,
-    campaign.advertising_channel_type,
-    ad_group.id,
-    ad_group.name,
-    ad_group.type,
-    ad_group_criterion.criterion_id,
-    ad_group_criterion.keyword.text,
-    metrics.impressions,
-    metrics.clicks,
-    metrics.cost_micros,
-    customer.currency_code 
-FROM keyword_view
-WHERE
-    segments.date DURING LAST_7_DAYS
-    and metrics.clicks > 10000
-ORDER BY
-    metrics.clicks DESC
-LIMIT 25
-                "#.to_string(),
-            },            
-        ])?
-        .build()
-        .await?;
+        // Generate embeddings for the definitions of all the documents using the specified embedding model.
+        let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
+            .documents(query_cookbook)?
+            .build()
+            .await?;
 
-    // Create vector store with the embeddings
-    let vector_store = InMemoryVectorStore::from_documents(embeddings);
+        // Create vector store with the embeddings
+        let vector_store = InMemoryVectorStore::from_documents(embeddings);
 
-    // Create vector store index
-    let index = vector_store.index(embedding_model);
+        // Create vector store index
+        let index = vector_store.index(embedding_model);
 
-    // Create OpenAI Agent with RAG context
-    let rag_agent = openai_client.agent("gpt-4o-mini")
-        .preamble("
-            You are a Google Ads GAQL query assistant here to assist the user to translate natural language query requests into valid GAQL. 
-            Respond with GAQL query as plain text, without any formatting or code blocks.
-            You will find example GAQL that could be useful in the attachments below.
-        ")
-        .dynamic_context(3, index)
-        .temperature(0.1)
-        .build();
+        let agent = client.agent(GPT_4O_MINI)
+            .preamble("
+                You are a Google Ads GAQL query assistant here to assist the user to translate natural language query requests into valid GAQL. 
+                Respond with GAQL query as plain text, without any formatting or code blocks.
+                You will find example GAQL that could be useful in the attachments below.
+            ")
+            .dynamic_context(10, index)
+            .temperature(0.1)
+            .build();
 
-    // HACK: dump full LLM prompt via CompletionRequest
-    let completion_request = rag_agent.completion(prompt, vec![]).await?.build();
-    log::debug!("LLM Preamble: {:?}, Prompt: {:?}", completion_request.preamble, completion_request.prompt_with_context());
+        Ok(RAGAgent { agent })
+    }
 
-    // Prompt the agent and print the response
-    let response = rag_agent.prompt(prompt).await?;
+    pub async fn prompt(&self, prompt: &str) -> Result<String, anyhow::Error> {
+        // HACK: dump full LLM prompt via CompletionRequest
+        let completion_request = self.agent.completion(prompt, vec![]).await?.build();
+        log::debug!("LLM Preamble: {:?}, Prompt: {:?}", completion_request.preamble, completion_request.prompt_with_context());
 
-    Ok(response)
+        // Prompt the agent 
+        self.agent.prompt(prompt).await.map_err(|e| anyhow::Error::new(e))
+    }
+}
+
+pub async fn convert_to_gaql(openai_api_key: &str, example_queries: Vec<QueryEntry>, prompt: &str) -> Result<String, anyhow::Error> {
+
+    // Initialize RAGAgent
+    let rag_agent = RAGAgent::init(&openai_api_key, example_queries).await?;
+
+    // Use RAGAgent to prompt
+    rag_agent.prompt(prompt).await
 }

--- a/src/prompt2gaql.rs
+++ b/src/prompt2gaql.rs
@@ -1,0 +1,167 @@
+use std::{env, vec};
+
+use rig::{
+    completion::Prompt,
+    embeddings::{embed::Embed, EmbedError, EmbeddingsBuilder, TextEmbedder},
+    providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
+    vector_store::in_memory_store::InMemoryVectorStore,
+};
+use serde::Serialize;
+
+// Data to be RAGged.
+// A vector search needs to be performed on the `definitions` field, so we derive the `Embed` trait for `WordDefinition`
+// and tag that field with `#[embed]`.
+#[derive(Serialize, Clone, Debug, Eq, PartialEq, Default)]
+struct ExampleQuery {
+    id: String,
+    description: String,
+    query: String,
+}
+
+impl Embed for ExampleQuery {
+    fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError> {
+        embedder.embed(self.description.clone());
+        Ok(())
+    }
+}
+
+pub async fn convert_to_gaql(prompt: &str) -> Result<String, anyhow::Error> {
+    // Create OpenAI client
+    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
+    let openai_client = Client::new(&openai_api_key);
+
+    let embedding_model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
+
+    // Generate embeddings for the definitions of all the documents using the specified embedding model.
+    let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
+        .documents(vec![
+            ExampleQuery {
+                id: "query0".to_string(),
+                description: "Performance of Shopping Campaigns for past 30 days".to_string(),
+                query: r#"
+SELECT 
+    customer.id, 
+    customer.descriptive_name,
+    campaign.id, 
+    campaign.name,
+    campaign.advertising_channel_type,
+    campaign.bidding_strategy_type,
+    campaign_budget.amount_micros,
+    metrics.average_cpc,
+    metrics.clicks, 
+    metrics.cost_micros,
+    customer.currency_code,
+    metrics.conversions,
+    metrics.cost_per_conversion,
+    metrics.conversions_value
+FROM campaign
+WHERE
+    campaign.advertising_channel_type IN ('SHOPPING') 
+    AND campaign.status IN ('ENABLED') 
+    AND segments.date DURING LAST_30_DAYS 
+    AND metrics.cost_micros > 100000000
+ORDER by metrics.cost_micros DESC
+                "#.to_string(),
+            },
+            ExampleQuery {
+                id: "query1".to_string(),
+                description: "Performance of Performance Max Campaigns for past 30 days".to_string(),
+                query: r#"
+SELECT 
+    campaign.id, 
+    segments.date,
+    metrics.impressions, 
+    metrics.clicks, 
+    metrics.cost_micros,
+    customer.currency_code 
+FROM campaign 
+WHERE 
+    segments.date DURING LAST_30_DAYS 
+    AND campaign.advertising_channel_type IN ('PERFORMANCE_MAX')
+    AND metrics.impressions > 1 
+ORDER BY 
+    segments.date, campaign.id
+                "#.to_string(),
+            },
+        ExampleQuery {
+                id: "query2".to_string(),
+                description: "Top Spending Smart Bidding Campaigns from past 7 days".to_string(),
+                query: r#"
+SELECT 
+    customer.id, 
+    customer.descriptive_name,
+    customer.currency_code,
+    campaign.id, 
+    campaign.name,
+    campaign.advertising_channel_type,
+    campaign.bidding_strategy_type,
+    campaign_budget.amount_micros,
+    metrics.average_cpc,
+    metrics.clicks, 
+    metrics.cost_micros,
+    metrics.conversions,
+    metrics.cost_per_conversion,
+    metrics.conversions_value
+FROM campaign
+WHERE
+    campaign.bidding_strategy_type IN ('MAXIMIZE_CONVERSIONS', 'MAXIMIZE_CONVERSION_VALUE', 'TARGET_CPA', 'TARGET_ROAS') 
+    AND campaign.status IN ('ENABLED') 
+    AND segments.date DURING LAST_7_DAYS 
+    AND metrics.cost_micros > 1000000000
+ORDER by metrics.cost_micros DESC
+LIMIT 25
+                "#.to_string(),
+            },
+            ExampleQuery {
+                id: "query3".to_string(),
+                description: "Top Keywords from last week".to_string(),
+                query: r#"
+SELECT
+    customer.id,
+    customer.descriptive_name,
+    campaign.id,
+    campaign.name,
+    campaign.advertising_channel_type,
+    ad_group.id,
+    ad_group.name,
+    ad_group.type,
+    ad_group_criterion.criterion_id,
+    ad_group_criterion.keyword.text,
+    metrics.impressions,
+    metrics.clicks,
+    metrics.cost_micros,
+    customer.currency_code 
+FROM keyword_view
+WHERE
+    segments.date DURING LAST_7_DAYS
+    and metrics.clicks > 10000
+ORDER BY
+    metrics.clicks DESC
+LIMIT 25
+                "#.to_string(),
+            },            
+        ])?
+        .build()
+        .await?;
+
+    // Create vector store with the embeddings
+    let vector_store = InMemoryVectorStore::from_documents(embeddings);
+
+    // Create vector store index
+    let index = vector_store.index(embedding_model);
+
+    let rag_agent = openai_client.agent("gpt-4")
+        .preamble("
+            You are a Google Ads GAQL query assistant here to assist the user to translate natural language query requests into valid GAQL. Respond with GAQL query only, and nothing else.
+            You will find example GAQL that could be useful below.
+        ")
+        .dynamic_context(3, index)
+        .build();
+
+    // Prompt the agent and print the response
+    let response = rag_agent.prompt(prompt).await?;
+
+    // println!("Generated GAQL Query: {}", response);
+
+    Ok(response)
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,15 +1,14 @@
 use anyhow::{bail, Result};
 use std::{
+    collections::HashMap,
     env,
     fs::File,
     io::{BufRead, BufReader, Read},
     path::Path,
-    collections::HashMap,
 };
 
-use toml::Value;
 use serde::Serialize;
-
+use toml::Value;
 
 #[allow(dead_code)]
 const CACHE_FILENAME: &str = ".cache";
@@ -132,8 +131,16 @@ pub struct QueryEntry {
 //   * "query": valid GAQL query
 impl QueryEntry {
     fn from_value(value: &Value) -> Self {
-        let description = value.get("description").and_then(|v| v.as_str()).unwrap_or("").to_string();
-        let query = value.get("query").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let description = value
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let query = value
+            .get("query")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
         QueryEntry { description, query }
     }
 }


### PR DESCRIPTION
Generating correct GAQL via RAG requires coming up with the right context in order to build the query. Context is hard.

This is a small step forward by limiting RAG to existing query cookbook.
