### PR TITLE
Make config file optional and remove default profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ Cargo.lock
 
 *.code-workspace
 *.json*
-*.md
 *.txt
 *.tsv
 *.csv

--- a/specs/no_default_profile.md
+++ b/specs/no_default_profile.md
@@ -1,0 +1,341 @@
+# No Default Profile
+
+## Problem
+
+Currently, when no `--profile` is specified, the CLI defaults to the "test" profile. This causes issues when using `--user` without a profile:
+
+```bash
+# This command tries to use "test" profile's MCC, but mhuang@themade.org's credentials
+mcc-gaql -c 3902228771 -q all_campaigns --user mhuang@themade.org
+
+# Error: Uses test profile's MCC which mhuang@themade.org doesn't have access to
+ERROR: The caller does not have permission to access customer
+```
+
+The user authenticated correctly with `--user mhuang@themade.org`, but the MCC customer ID came from the "test" profile config, which that user doesn't have permission to access.
+
+## Proposed Solution
+
+1. **No default profile**: Remove the automatic fallback to "test" profile
+2. **Config-free mode**: Allow full operation using only CLI arguments
+3. **Use customer_id as MCC**: When no profile and no `--mcc` specified, use `--customer-id` as the MCC
+4. **Clear error messages**: When insufficient information provided, explain what's needed
+
+## Implementation Plan
+
+### 1. Add `--mcc` CLI Argument
+
+Already implemented in `src/args.rs`:
+
+```rust
+/// MCC (Manager) Customer ID for login-customer-id header
+#[clap(short = 'm', long)]
+pub mcc: Option<String>,
+```
+
+### 2. Update `src/main.rs` - Config Loading Logic
+
+Change from:
+```rust
+let profile = &args.profile.unwrap_or_else(|| "test".to_owned());
+let config = config::load(profile).context(...)?;
+```
+
+To:
+```rust
+// Only load config if profile is explicitly specified
+let config = if let Some(profile) = &args.profile {
+    log::info!("Config profile: {profile}");
+    Some(config::load(profile).context(format!("Loading config for profile: {profile}"))?)
+} else {
+    log::info!("No profile specified, using CLI arguments only");
+    None
+};
+```
+
+### 3. Update User Email Resolution
+
+Change from:
+```rust
+let user_email = args.user.as_deref().or(config.user.as_deref());
+```
+
+To:
+```rust
+// Priority: CLI arg > config file > None
+let user_email = args.user.as_deref()
+    .or_else(|| config.as_ref().and_then(|c| c.user.as_deref()));
+```
+
+### 4. Update MCC Customer ID Resolution
+
+Add new resolution logic with priority:
+1. CLI `--mcc` argument (highest priority)
+2. CLI `--customer-id` argument (fallback when no --mcc)
+3. Config file `mcc_customerid`
+4. Error if none provided (lowest priority)
+
+```rust
+// Priority: CLI --mcc > CLI --customer-id > config file
+let mcc_customer_id = args.mcc.as_ref()
+    .or(args.customer_id.as_ref())
+    .map(|s| s.as_str())
+    .or_else(|| config.as_ref().map(|c| c.mcc_customerid.as_str()))
+    .ok_or_else(|| anyhow::anyhow!(
+        "MCC customer ID required. Either:\n  \
+         1. Provide via CLI: --mcc <MCC_ID> or --customer-id <CUSTOMER_ID>\n  \
+         2. Specify config profile: --profile <PROFILE_NAME>"
+    ))?;
+```
+
+### 5. Update All Config References
+
+Throughout `main.rs`, update all direct config field accesses to handle `Option<MyConfig>`:
+
+**Line ~50: Queries filename**
+```rust
+// Before
+let query_filename = config.queries_filename.as_ref()
+    .expect("Query cookbook filename undefined");
+
+// After
+let query_filename = config.as_ref()
+    .and_then(|c| c.queries_filename.as_ref())
+    .ok_or_else(|| anyhow::anyhow!(
+        "Query cookbook not available. Either:\n  \
+         1. Provide GAQL query directly: <QUERY>\n  \
+         2. Specify config profile with queries_filename: --profile <PROFILE_NAME>"
+    ))?;
+```
+
+**Line ~76: Queries filename for natural language**
+```rust
+// Before
+let query_filename = config.queries_filename.as_ref()
+    .expect("Query cookbook filename undefined");
+
+// After
+let query_filename = config.as_ref()
+    .and_then(|c| c.queries_filename.as_ref())
+    .ok_or_else(|| anyhow::anyhow!(
+        "Query cookbook required for natural language mode. \
+         Specify config profile with queries_filename: --profile <PROFILE_NAME>"
+    ))?;
+```
+
+**Line ~113-140: API access calls**
+```rust
+// Before
+googleads::get_api_access(
+    &config.mcc_customerid,
+    user_email,
+    config.token_cache_filename.as_deref(),
+).await
+
+// After
+googleads::get_api_access(
+    mcc_customer_id,
+    user_email,
+    config.as_ref().and_then(|c| c.token_cache_filename.as_deref()),
+).await
+```
+
+**Line ~126-132: Token cache cleanup**
+```rust
+// Before
+let token_cache_filename = if let Some(legacy) = &config.token_cache_filename {
+    legacy.clone()
+} else if let Some(email) = user_email {
+    googleads::generate_token_cache_filename(email)
+} else {
+    "tokencache_default.json".to_string()
+};
+
+// After
+let token_cache_filename = config.as_ref()
+    .and_then(|c| c.token_cache_filename.as_ref().cloned())
+    .or_else(|| user_email.map(googleads::generate_token_cache_filename))
+    .unwrap_or_else(|| "tokencache_default.json".to_string());
+```
+
+**Line ~159-165: List child accounts - MCC reference**
+```rust
+// Before
+log::debug!(
+    "Listing ALL child accounts under MCC {}",
+    &config.mcc_customerid
+);
+(
+    config.mcc_customerid,
+    googleads::SUB_ACCOUNTS_QUERY.to_owned(),
+)
+
+// After
+log::debug!(
+    "Listing ALL child accounts under MCC {}",
+    mcc_customer_id
+);
+(
+    mcc_customer_id.to_string(),
+    googleads::SUB_ACCOUNTS_QUERY.to_owned(),
+)
+```
+
+**Line ~212: Query all linked child accounts**
+```rust
+// Before
+let customer_id = config.mcc_customerid;
+
+// After
+let customer_id = mcc_customer_id.to_string();
+```
+
+**Line ~220-229: CustomerIDs file**
+```rust
+// Before
+if config.customerids_filename.is_some() {
+    let customerids_path =
+        crate::config::config_file_path(&config.customerids_filename.unwrap()).unwrap();
+    log::debug!("Querying accounts listed in file: {}", customerids_path.display());
+    (util::get_child_account_ids_from_file(customerids_path.as_path()).await).ok()
+} else {
+    log::warn!("Expecting customerids file but none found in config");
+    None
+}
+
+// After
+if let Some(customerids_filename) = config.as_ref().and_then(|c| c.customerids_filename.as_ref()) {
+    let customerids_path =
+        crate::config::config_file_path(customerids_filename).unwrap();
+    log::debug!("Querying accounts listed in file: {}", customerids_path.display());
+    (util::get_child_account_ids_from_file(customerids_path.as_path()).await).ok()
+} else {
+    log::warn!("No customerids file specified. Use --customer-id or --all-linked-child-accounts");
+    None
+}
+```
+
+### 6. Update Config Module (Optional)
+
+In `src/config.rs`, the `load()` function signature can remain the same since it already returns `Result<MyConfig>`. The caller in `main.rs` will handle whether to call it or not.
+
+## Usage Examples
+
+### Config-Free Mode (NEW)
+
+```bash
+# Single account query - user's own account
+mcc-gaql -c 3902228771 -q all_campaigns --user mhuang@themade.org
+
+# Query with explicit MCC different from customer account
+mcc-gaql -c 1234567890 --mcc 9876543210 -q all_campaigns --user mhuang@themade.org
+
+# Query all linked accounts under MCC
+mcc-gaql --mcc 9876543210 --all-linked-child-accounts -q all_campaigns --user mhuang@themade.org
+```
+
+### Profile-Based Mode (EXISTING - Still Works)
+
+```bash
+# Use test profile (must specify explicitly now)
+mcc-gaql --profile test -q all_campaigns
+
+# Override profile's MCC
+mcc-gaql --profile test --mcc 9876543210 -q all_campaigns
+
+# Override profile's user
+mcc-gaql --profile test --user other@example.com -q all_campaigns
+```
+
+### Error Messages
+
+**Missing MCC and profile:**
+```bash
+$ mcc-gaql -q all_campaigns --user mhuang@themade.org
+Error: MCC customer ID required. Either:
+  1. Provide via CLI: --mcc <MCC_ID> or --customer-id <CUSTOMER_ID>
+  2. Specify config profile: --profile <PROFILE_NAME>
+```
+
+**Stored query without profile:**
+```bash
+$ mcc-gaql -c 3902228771 -q all_campaigns --user mhuang@themade.org
+Error: Query cookbook not available. Either:
+  1. Provide GAQL query directly: <QUERY>
+  2. Specify config profile with queries_filename: --profile <PROFILE_NAME>
+```
+
+**Natural language mode without profile:**
+```bash
+$ mcc-gaql -c 3902228771 -n "show me campaigns" --user mhuang@themade.org
+Error: Query cookbook required for natural language mode. Specify config profile with queries_filename: --profile <PROFILE_NAME>
+```
+
+## Testing Plan
+
+1. **Test config-free mode:**
+   ```bash
+   mcc-gaql -c 3902228771 "SELECT campaign.id, campaign.name FROM campaign" --user mhuang@themade.org
+   ```
+
+2. **Test with --mcc override:**
+   ```bash
+   mcc-gaql -c 1111111111 --mcc 2222222222 "SELECT ..." --user mhuang@themade.org
+   ```
+
+3. **Test profile mode still works:**
+   ```bash
+   mcc-gaql --profile test -q all_campaigns
+   ```
+
+4. **Test error messages:**
+   ```bash
+   # Should error with helpful message
+   mcc-gaql -q all_campaigns --user mhuang@themade.org
+   ```
+
+5. **Test stored queries require profile:**
+   ```bash
+   # Should error explaining need profile for query cookbook
+   mcc-gaql -c 3902228771 -q all_campaigns --user mhuang@themade.org
+   ```
+
+## Migration Guide
+
+### For Existing Users
+
+**Before (implicit test profile):**
+```bash
+mcc-gaql -q all_campaigns
+```
+
+**After (explicit profile required):**
+```bash
+mcc-gaql --profile test -q all_campaigns
+```
+
+**Or switch to config-free mode:**
+```bash
+mcc-gaql -c 3902228771 "SELECT campaign.id FROM campaign" --user your@email.com
+```
+
+### For New Users
+
+New users can start without any config file:
+```bash
+mcc-gaql -c YOUR_CUSTOMER_ID "YOUR_GAQL_QUERY" --user your@email.com
+```
+
+## Benefits
+
+1. **No magic defaults**: Explicit is better than implicit
+2. **Config-free usage**: Can use tool without creating config file
+3. **Better error messages**: Clear guidance when information is missing
+4. **Prevents auth confusion**: Each user's credentials map to correct MCC
+5. **Flexible**: Still supports profiles for complex setups
+
+## Breaking Changes
+
+**Breaking:** Commands without `--profile` will no longer default to "test" profile.
+
+**Migration:** Existing scripts/aliases that rely on implicit "test" profile must add `--profile test` explicitly.

--- a/specs/oauth_token_caching_without_config_file.md
+++ b/specs/oauth_token_caching_without_config_file.md
@@ -1,0 +1,241 @@
+# OAuth Token Caching Without Config File
+
+## Overview
+
+Implement user-based token caching so users can specify their email via `--user` argument (or config file) instead of manually managing token cache filenames. The token cache filename will be auto-generated from the user email.
+
+## Current Behavior
+
+- Token cache filename must be specified in config file: `token_cache_filename = "tokencache.json"`
+- No association between the cached token and the authenticated user
+- Users must manually manage which cache file corresponds to which Google account
+
+## Proposed Behavior
+
+- Add `--user` CLI argument to specify user email for OAuth2 authentication
+- Add optional `user` field to config file
+- Auto-generate token cache filename from user email: `tokencache_{sanitized_email}.json`
+- Remove requirement for `token_cache_filename` in config (make it optional)
+- Support backward compatibility for existing configs with `token_cache_filename`
+
+## Implementation Plan
+
+### 1. Update CLI Arguments (`src/args.rs`)
+
+Add new `--user` argument:
+
+```rust
+/// User email for OAuth2 authentication (auto-generates token cache)
+#[clap(short = 'u', long)]
+pub user: Option<String>,
+```
+
+### 2. Update Config Structure (`src/config.rs`)
+
+Modify `MyConfig` struct:
+
+```rust
+#[derive(Deserialize, Serialize, Debug)]
+pub struct MyConfig {
+    /// MCC Account ID is mandatory
+    pub mcc_customerid: String,
+
+    /// Optional user email for OAuth2 (preferred over token_cache_filename)
+    pub user: Option<String>,
+
+    /// Token Cache filename (legacy - use 'user' instead)
+    pub token_cache_filename: Option<String>,
+
+    /// Optional file containing child customer_ids to query
+    pub customerids_filename: Option<String>,
+
+    /// Optional TOML file with stored queries
+    pub queries_filename: Option<String>,
+}
+```
+
+### 3. Update Google Ads API Access (`src/googleads.rs`)
+
+#### 3.1 Add Helper Function
+
+Add function to generate sanitized token cache filename from email:
+
+```rust
+/// Generate token cache filename from user email
+/// Sanitizes email by replacing @ with _at_ and . with _
+/// Example: user@example.com -> tokencache_user_at_example_com.json
+fn generate_token_cache_filename(user_email: &str) -> String {
+    let sanitized = user_email
+        .replace('@', "_at_")
+        .replace('.', "_");
+    format!("tokencache_{}.json", sanitized)
+}
+```
+
+#### 3.2 Update `get_api_access()` Signature
+
+Change from:
+```rust
+pub async fn get_api_access(
+    mcc_customer_id: &str,
+    token_cache_filename: &str,
+) -> Result<GoogleAdsAPIAccess>
+```
+
+To:
+```rust
+pub async fn get_api_access(
+    mcc_customer_id: &str,
+    user_email: Option<&str>,
+    legacy_token_cache_filename: Option<&str>,
+) -> Result<GoogleAdsAPIAccess>
+```
+
+#### 3.3 Implement Token Cache Resolution Logic
+
+```rust
+let token_cache_filename = if let Some(legacy) = legacy_token_cache_filename {
+    // Legacy path: use explicit filename
+    legacy.to_string()
+} else if let Some(email) = user_email {
+    // New path: auto-generate from email
+    generate_token_cache_filename(email)
+} else {
+    // Default: use generic cache name
+    "tokencache_default.json".to_string()
+};
+```
+
+### 4. Update Main Application Logic (`src/main.rs`)
+
+#### 4.1 Resolve User Email with Priority
+
+```rust
+// Priority: CLI arg > config file > None
+let user_email = args.user.as_deref().or(config.user.as_deref());
+```
+
+#### 4.2 Update API Access Calls
+
+Change from:
+```rust
+googleads::get_api_access(&config.mcc_customerid, &config.token_cache_filename).await
+```
+
+To:
+```rust
+googleads::get_api_access(
+    &config.mcc_customerid,
+    user_email,
+    config.token_cache_filename.as_deref()
+).await
+```
+
+Update both calls (lines 110 and 122 in current code).
+
+#### 4.3 Update Error Handling for Token Cache Cleanup
+
+When clearing invalid token cache (around line 119), need to determine the cache filename:
+
+```rust
+let token_cache_filename = if let Some(legacy) = &config.token_cache_filename {
+    legacy.clone()
+} else if let Some(email) = user_email {
+    googleads::generate_token_cache_filename(email)
+} else {
+    "tokencache_default.json".to_string()
+};
+
+let token_cache_path = crate::config::config_file_path(&token_cache_filename)
+    .expect("token cache path");
+let _ = fs::remove_file(token_cache_path);
+```
+
+### 5. Update GoogleAdsAPIAccess Struct (Optional Enhancement)
+
+Add user email to struct for tracking:
+
+```rust
+#[derive(Clone)]
+pub struct GoogleAdsAPIAccess {
+    pub channel: Channel,
+    pub dev_token: MetadataValue<Ascii>,
+    pub login_customer: MetadataValue<Ascii>,
+    pub auth_token: Option<MetadataValue<Ascii>>,
+    pub token: Option<AccessToken>,
+    pub authenticator: Authenticator<<DefaultHyperClient as HyperClientBuilder>::Connector>,
+    pub user_email: Option<String>,  // NEW: track which user is authenticated
+}
+```
+
+## Example Usage
+
+### Command Line
+
+```bash
+# Use specific user
+mcc-gaql --user user@example.com -q some_query
+
+# Uses config file 'user' field
+mcc-gaql -q some_query
+
+# Legacy: config file still has token_cache_filename
+mcc-gaql -q some_query
+```
+
+### Config File Examples
+
+#### New approach (recommended):
+```toml
+[test]
+mcc_customerid = "1234567890"
+user = "user@example.com"
+customerids_filename = "customerids_test.txt"
+queries_filename = "query_cookbook.toml"
+```
+
+#### Legacy approach (still supported):
+```toml
+[test]
+mcc_customerid = "1234567890"
+token_cache_filename = "tokencache.json"
+customerids_filename = "customerids_test.txt"
+queries_filename = "query_cookbook.toml"
+```
+
+## Backward Compatibility
+
+- Existing configs with `token_cache_filename` will continue to work
+- If both `user` and `token_cache_filename` are present, `token_cache_filename` takes precedence (legacy wins)
+- No breaking changes to existing deployments
+
+## Token Cache File Locations
+
+Token cache files will be stored in the standard config directory:
+- macOS: `~/Library/Application Support/mcc-gaql/tokencache_{user}.json`
+- Linux: `~/.config/mcc-gaql/tokencache_{user}.json`
+- Windows: `C:\Users\{username}\AppData\Roaming\mcc-gaql\tokencache_{user}.json`
+
+## Environment Variable Override
+
+Users can still override via environment variable:
+```bash
+export MCC_GAQL_USER="user@example.com"
+```
+
+## Testing Considerations
+
+1. Test with `--user` argument
+2. Test with `user` in config file
+3. Test legacy `token_cache_filename` still works
+4. Test default behavior (no user, no token_cache_filename)
+5. Test email sanitization with special characters
+6. Test multiple users can have separate token caches
+7. Test token cache cleanup on auth failure
+
+## Future Enhancements
+
+1. Add `--list-users` command to show cached authentications
+2. Add `--clear-cache` command to remove specific user's token
+3. Store metadata file mapping users to their cache files and last used timestamp
+4. Auto-detect user from existing token cache using Google's userinfo API

--- a/specs/polars_jsonwriter_vs_serdejson.md
+++ b/specs/polars_jsonwriter_vs_serdejson.md
@@ -1,0 +1,206 @@
+# Polars JsonWriter vs serde_json Investigation
+
+**Date**: 2025-10-22
+**Author**: Investigation into using Polars built-in JSON writer
+
+## Executive Summary
+
+**Recommendation: Do NOT upgrade to use Polars JsonWriter at this time.**
+
+The current custom implementation using `serde_json` should be maintained. While Polars JsonWriter would simplify the code, the upgrade costs (compilation bugs in 0.42, breaking API changes in 0.51+) significantly outweigh the benefits.
+
+---
+
+## Current State
+
+### Polars Version
+- **Current version**: 0.42.0
+- **Features enabled**: `["lazy", "serde-lazy"]`
+
+### Current JSON Implementation
+- **Location**: src/main.rs:493-575
+- **Functions**: `write_json()` and `write_json_to_stdout()`
+- **Implementation**: Custom implementation using `serde_json`
+- **Approach**:
+  - Iterates through DataFrame rows and columns
+  - Converts each value to appropriate JSON type (integer, float, null, string)
+  - Builds JSON array of objects manually
+  - ~80 lines per function
+
+---
+
+## Investigation Findings
+
+### Version 0.42.0 (Current)
+
+**Status**: JSON feature is BROKEN
+
+**Issues**:
+- The `json` feature exists but has a critical compilation bug when used with `lazy` feature
+- Compilation error: `error[E0412]: cannot find type 'CloudOptions' in this scope`
+- Occurs in: `polars-plan-0.42.0/src/plans/functions/count.rs:189:28`
+- Related GitHub issue: [#18416](https://github.com/pola-rs/polars/issues/18416)
+
+**Workaround**:
+- Adding `parquet` feature resolves the compilation error
+- However, this adds unnecessary dependencies for cloud storage features
+
+**Conclusion**: Not viable for production use
+
+### Version 0.51.0 (Latest Stable)
+
+**Status**: JSON feature works, but requires extensive refactoring
+
+**What Works**:
+- The `json` feature compiles successfully
+- JsonWriter is available and functional
+- Provides two output formats:
+  - `JsonFormat::Json` - Standard JSON array of objects
+  - `JsonFormat::JsonLines` - Newline-delimited JSON (NDJSON)
+
+**Breaking API Changes Required**:
+
+1. **Series::new() signature change**
+   - Old (0.42): `Series::new(&str, values)`
+   - New (0.51): `Series::new(PlSmallStr, values)`
+   - Fix: Add `.into()` to all string literals: `Series::new("name".into(), values)`
+   - Affected locations: src/googleads.rs:270, 276, 280
+
+2. **DataFrame::new() signature change**
+   - Old (0.42): `DataFrame::new(Vec<Series>)`
+   - New (0.51): `DataFrame::new(Vec<Column>)`
+   - Requires converting Series to Column types
+   - Affected locations: src/googleads.rs:285
+
+**Code Impact**:
+- Multiple changes across src/googleads.rs
+- Potential changes in other files using Polars API
+- Comprehensive testing required after upgrade
+
+**Benefits if Upgraded**:
+- Simpler JSON output code (~80 lines → ~6 lines per function)
+- Example simplified code:
+  ```rust
+  fn write_json_to_stdout(df: &mut DataFrame) -> Result<()> {
+      let mut buf = Vec::new();
+      JsonWriter::new(&mut buf)
+          .with_json_format(JsonFormat::Json)
+          .finish(df)?;
+      print!("{}", String::from_utf8(buf)?);
+      Ok(())
+  }
+  ```
+
+---
+
+## Current Implementation Analysis
+
+### Strengths
+1. **Reliable**: Works correctly with current Polars 0.42.0
+2. **Type-safe**: Proper handling of different data types (integers, floats, nulls, strings)
+3. **No extra dependencies**: Uses only `serde_json` which is already a dependency
+4. **Readable**: Logic is clear and easy to understand
+5. **Maintainable**: Self-contained implementation
+
+### Code Quality
+The current implementation (src/main.rs:493-575):
+- Properly converts DataFrame values to appropriate JSON types
+- Handles edge cases (null values, string quoting)
+- Distinguishes between integers and floats
+- Creates clean JSON output compatible with LLM tools
+
+---
+
+## Recommendations
+
+### Short Term (Current)
+**Keep the existing `serde_json` implementation**
+
+Reasons:
+1. Version 0.42.0 JSON feature is broken
+2. Version 0.51.0 requires too much refactoring for minimal benefit
+3. Current implementation is solid and working well
+4. No urgent need for code simplification
+
+### Medium Term (6-12 months)
+**Re-evaluate when Polars 1.0 stable is released**
+
+Actions:
+1. Monitor Polars release notes for API stabilization
+2. Wait for Polars 1.0 with more stable, mature APIs
+3. Consider upgrade during a major refactoring effort
+4. Ensure comprehensive test coverage before attempting upgrade
+
+### Long Term
+**Consider upgrade to latest Polars during major codebase refactoring**
+
+Conditions for upgrade:
+1. Polars API has stabilized (1.0+ releases)
+2. Planning broader codebase refactoring anyway
+3. Can dedicate time for comprehensive testing
+4. Benefits extend beyond just JSON writing (e.g., performance, new features)
+
+---
+
+## Cost-Benefit Analysis
+
+### Benefits of Upgrading
+- Cleaner code (~150 lines reduced across both JSON functions)
+- Native Polars integration
+- Potential performance improvements (though likely negligible for typical use)
+
+### Costs of Upgrading
+- Breaking changes across multiple files
+- Risk of introducing bugs during migration
+- Comprehensive testing required
+- Time investment for refactoring
+- Potential for new issues with Polars API changes
+
+### Verdict
+**Costs significantly outweigh benefits.** The code simplification is nice but not essential, while the upgrade risks and effort are substantial.
+
+---
+
+## Technical Details
+
+### Polars JsonWriter API (v0.51+)
+```rust
+use polars::prelude::*;
+
+// Write to stdout
+let mut buf = Vec::new();
+JsonWriter::new(&mut buf)
+    .with_json_format(JsonFormat::Json)
+    .finish(&mut df)?;
+print!("{}", String::from_utf8(buf)?);
+
+// Write to file
+let f = File::create(outfile)?;
+JsonWriter::new(f)
+    .with_json_format(JsonFormat::Json)
+    .finish(&mut df)?;
+```
+
+### Required Cargo.toml Change
+```toml
+# Current
+polars = { version = "0.42", features = ["lazy", "serde-lazy"] }
+
+# For JsonWriter (0.51+)
+polars = { version = "0.51", features = ["lazy", "serde-lazy", "json"] }
+```
+
+---
+
+## References
+
+- [Polars GitHub Issue #18416](https://github.com/pola-rs/polars/issues/18416) - JSON + lazy feature compilation bug
+- [Polars GitHub Issue #19643](https://github.com/pola-rs/polars/issues/19643) - PlSmallStr conversion changes
+- [Polars JsonWriter Documentation](https://docs.rs/polars/latest/polars/prelude/struct.JsonWriter.html)
+- Current implementation: src/main.rs:493-575
+
+---
+
+## Conclusion
+
+The investigation confirms that while Polars JsonWriter is a cleaner solution in theory, the practical barriers make it unsuitable for adoption at this time. The current `serde_json` implementation is well-written, reliable, and should be maintained until Polars APIs stabilize and a natural refactoring opportunity arises.

--- a/src/args.rs
+++ b/src/args.rs
@@ -61,11 +61,15 @@ pub struct Cli {
     #[clap(short = 'u', long)]
     pub user: Option<String>,
 
-    /// MCC (Manager) Customer ID for login-customer-id header
+    /// MCC (Manager) Customer ID for login-customer-id header.
+    /// Required unless specified in config profile.
+    /// For solo accounts, can be omitted if --customer-id is provided.
     #[clap(short = 'm', long)]
     pub mcc: Option<String>,
 
-    /// Apply query to a single CustomerID. Or use with `--all-linked-child-accounts` to query all child accounts.
+    /// Apply query to a single account.
+    /// If no --mcc is specified, this will be used as the MCC (for solo accounts).
+    /// To query across many accounts, specify a customerids_filename in config file, or query across all child accounts via --all-linked-child-accounts.
     #[clap(short, long)]
     pub customer_id: Option<String>,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -56,6 +56,14 @@ pub struct Cli {
     #[clap(short, long)]
     pub profile: Option<String>,
 
+    /// User email for OAuth2 authentication (auto-generates token cache)
+    #[clap(short = 'u', long)]
+    pub user: Option<String>,
+
+    /// MCC (Manager) Customer ID for login-customer-id header
+    #[clap(short = 'm', long)]
+    pub mcc: Option<String>,
+
     /// Apply query to a single CustomerID. Or use with `--all-linked-child-accounts` to query all child accounts.
     #[clap(short, long)]
     pub customer_id: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,32 @@ pub struct MyConfig {
     pub queries_filename: Option<String>,
 }
 
+// Add extension trait for cleaner access
+pub trait ConfigExt {
+    fn queries_filename(&self) -> Option<&String>;
+    fn customerids_filename(&self) -> Option<&String>;
+    fn token_cache_filename(&self) -> Option<&String>;
+    fn user(&self) -> Option<&str>;
+}
+
+impl ConfigExt for Option<MyConfig> {
+    fn queries_filename(&self) -> Option<&String> {
+        self.as_ref().and_then(|c| c.queries_filename.as_ref())
+    }
+
+    fn customerids_filename(&self) -> Option<&String> {
+        self.as_ref().and_then(|c| c.customerids_filename.as_ref())
+    }
+
+    fn token_cache_filename(&self) -> Option<&String> {
+        self.as_ref().and_then(|c| c.token_cache_filename.as_ref())
+    }
+
+    fn user(&self) -> Option<&str> {
+        self.as_ref().and_then(|c| c.user.as_deref())
+    }
+}
+
 pub fn load(profile: &str) -> anyhow::Result<MyConfig> {
     log::info!("Config profile: {profile}");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,8 +13,10 @@ pub const ENV_VAR_PREFIX: &str = "MCC_GAQL_";
 pub struct MyConfig {
     /// MCC Account ID is mandatory
     pub mcc_customerid: String,
-    /// Token Cache filename
-    pub token_cache_filename: String,
+    /// Optional user email for OAuth2 (preferred over token_cache_filename)
+    pub user: Option<String>,
+    /// Token Cache filename (legacy - use 'user' instead)
+    pub token_cache_filename: Option<String>,
     /// Optional file containing child customer_ids to query
     pub customerids_filename: Option<String>,
     /// Optional TOML file with stored queries

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,27 +40,30 @@ impl ResolvedConfig {
         config: Option<MyConfig>,
     ) -> anyhow::Result<Self> {
         // Resolve MCC with priority: CLI --mcc > CLI --customer-id > config
-        let mcc_customer_id = args.mcc.as_ref()
+        let mcc_customer_id = args
+            .mcc
+            .as_ref()
             .or(args.customer_id.as_ref())
             .map(|s| s.to_string())
             .or_else(|| config.as_ref().map(|c| c.mcc_customerid.clone()))
-            .ok_or_else(|| anyhow::anyhow!(
-                "MCC customer ID required. Either:\n  \
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "MCC customer ID required. Either:\n  \
                  1. Provide via CLI: --mcc <MCC_ID> or --customer-id <CUSTOMER_ID>\n  \
                  2. Specify config profile: --profile <PROFILE_NAME>"
-            ))?;
+                )
+            })?;
 
         // Resolve user email: CLI > config
-        let user_email = args.user.clone()
+        let user_email = args
+            .user
+            .clone()
             .or_else(|| config.as_ref().and_then(|c| c.user.clone()));
 
         // Config file fields (only available if profile specified)
-        let token_cache_filename = config.as_ref()
-            .and_then(|c| c.token_cache_filename.clone());
-        let queries_filename = config.as_ref()
-            .and_then(|c| c.queries_filename.clone());
-        let customerids_filename = config.as_ref()
-            .and_then(|c| c.customerids_filename.clone());
+        let token_cache_filename = config.as_ref().and_then(|c| c.token_cache_filename.clone());
+        let queries_filename = config.as_ref().and_then(|c| c.queries_filename.clone());
+        let customerids_filename = config.as_ref().and_then(|c| c.customerids_filename.clone());
 
         Ok(Self {
             mcc_customer_id,
@@ -72,12 +75,13 @@ impl ResolvedConfig {
     }
 
     pub fn require_queries_filename(&self) -> anyhow::Result<&str> {
-        self.queries_filename.as_deref()
-            .ok_or_else(|| anyhow::anyhow!(
+        self.queries_filename.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
                 "Query cookbook not available. Either:\n  \
                  1. Provide GAQL query directly: <QUERY>\n  \
                  2. Specify config profile with queries_filename: --profile <PROFILE_NAME>"
-            ))
+            )
+        })
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,20 @@ impl ResolvedConfig {
 
     /// Validate that resolved config supports the requested operation mode
     pub fn validate_for_operation(&self, args: &crate::args::Cli) -> anyhow::Result<()> {
+        // Validate that user context is always specified before running any operation
+        // This ensures we know which user's credentials we're using
+        if self.user_email.is_none() {
+            return Err(anyhow::anyhow!(
+                "User context required for authentication.\n\
+                 A user email must be specified to identify which Google Ads account credentials to use.\n\
+                 Please provide one of:\n  \
+                 1. CLI argument: --user <EMAIL>\n  \
+                 2. Config profile with 'user' field: --profile <PROFILE_NAME>\n\n\
+                 Without a user context, it's unclear which user's token is being used,\n\
+                 which may result in using incorrect credentials."
+            ));
+        }
+
         // Validate natural language mode requirements
         if args.natural_language && self.queries_filename.is_none() {
             return Err(anyhow::anyhow!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,8 +75,7 @@ impl ResolvedConfig {
         let mcc_customer_id = if let Some(mcc) = &args.mcc {
             // Explicit --mcc takes highest priority
             log::debug!("Using MCC from --mcc argument: {}", mcc);
-            validate_and_normalize_customer_id(mcc)
-                .context("Invalid --mcc argument")?
+            validate_and_normalize_customer_id(mcc).context("Invalid --mcc argument")?
         } else if let Some(config_mcc) = config.as_ref().map(|c| &c.mcc_customerid) {
             // Config file MCC is second priority
             log::debug!("Using MCC from config profile: {}", config_mcc);
@@ -224,17 +223,14 @@ pub fn load(profile: &str) -> anyhow::Result<MyConfig> {
     figment = figment.merge(Env::prefixed(ENV_VAR_PREFIX));
 
     // Extract the profile with better error context
-    figment
-        .select(profile)
-        .extract()
-        .map_err(|e| {
-            // Try to provide helpful context about what went wrong
-            let config_path = config_file_path(TOML_CONFIG_FILENAME)
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| "unknown".to_string());
+    figment.select(profile).extract().map_err(|e| {
+        // Try to provide helpful context about what went wrong
+        let config_path = config_file_path(TOML_CONFIG_FILENAME)
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "unknown".to_string());
 
-            anyhow::anyhow!(
-                "Failed to load profile '{}' from config file: {}\n\
+        anyhow::anyhow!(
+            "Failed to load profile '{}' from config file: {}\n\
                  Error: {}\n\
                  \n\
                  Possible issues:\n\
@@ -243,12 +239,12 @@ pub fn load(profile: &str) -> anyhow::Result<MyConfig> {
                  - TOML syntax may be invalid\n\
                  \n\
                  Check your config file format and ensure the profile exists.",
-                profile,
-                config_path,
-                e,
-                profile
-            )
-        })
+            profile,
+            config_path,
+            e,
+            profile
+        )
+    })
 }
 
 /// get the platform-correct config file path
@@ -292,20 +288,24 @@ mod tests {
     fn test_validate_customer_id_invalid_chars() {
         let result = validate_and_normalize_customer_id("123abc7890");
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid customer ID format"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid customer ID format")
+        );
     }
 
     #[test]
     fn test_validate_customer_id_invalid_chars_with_spaces() {
         let result = validate_and_normalize_customer_id("123 456 7890");
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid customer ID format"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid customer ID format")
+        );
     }
 
     #[test]
@@ -330,9 +330,11 @@ mod tests {
     fn test_validate_customer_id_empty() {
         let result = validate_and_normalize_customer_id("");
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid customer ID length"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid customer ID length")
+        );
     }
 }

--- a/src/googleads.rs
+++ b/src/googleads.rs
@@ -144,32 +144,12 @@ pub fn generate_token_cache_filename(user_email: &str) -> String {
     format!("tokencache_{}.json", sanitized)
 }
 
-/// Resolve token cache filename based on priority:
-/// 1. Explicit legacy token cache filename (highest priority)
-/// 2. Auto-generated from user email
-/// 3. Default filename (lowest priority)
-pub fn resolve_token_cache_filename(
-    legacy_filename: Option<&str>,
-    user_email: Option<&str>,
-) -> String {
-    if let Some(legacy) = legacy_filename {
-        legacy.to_string()
-    } else if let Some(email) = user_email {
-        generate_token_cache_filename(email)
-    } else {
-        "tokencache_default.json".to_string()
-    }
-}
-
 /// Get access to Google Ads API via OAuth2 flow and return API Credentials
 pub async fn get_api_access(
     mcc_customer_id: &str,
+    token_cache_filename: &str,
     user_email: Option<&str>,
-    legacy_token_cache_filename: Option<&str>,
 ) -> Result<GoogleAdsAPIAccess> {
-    // Determine token cache filename based on priority: legacy > user email > default
-    let token_cache_filename =
-        resolve_token_cache_filename(legacy_token_cache_filename, user_email);
     let client_secret_path =
         crate::config::config_file_path(FILENAME_CLIENT_SECRET).expect("clientsecret path");
 
@@ -179,7 +159,7 @@ pub async fn get_api_access(
             .expect("clientsecret.json");
 
     let token_cache_path =
-        crate::config::config_file_path(&token_cache_filename).expect("token cache path");
+        crate::config::config_file_path(token_cache_filename).expect("token cache path");
 
     let auth: Authenticator<<DefaultHyperClient as HyperClientBuilder>::Connector> =
         InstalledFlowAuthenticator::builder(app_secret, InstalledFlowReturnMethod::HTTPRedirect)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,10 @@
+//
+// Author: Michael S. Huang (mhuang74@gmail.com)
+//
+// Library module exposing public APIs for testing and potential reuse
+
+pub mod args;
+pub mod config;
+pub mod googleads;
+pub mod prompt2gaql;
+pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -675,5 +675,3 @@ fn output_dataframe(
     }
     Ok(())
 }
-
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,23 +130,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await
     .context(format!(
         "Initial OAuth2 authentication failed for MCC: {}, User: {:?}",
-        mcc_customer_id,
-        user_email
+        mcc_customer_id, user_email
     )) {
         Ok(a) => a,
         Err(e) => {
-            log::warn!("Authentication failed: {}. Attempting re-auth by clearing token cache", e);
+            log::warn!(
+                "Authentication failed: {}. Attempting re-auth by clearing token cache",
+                e
+            );
 
             // remove cached token to force re-auth and try again
             let token_cache_path =
                 mcc_gaql::config::config_file_path(&resolved_config.token_cache_filename)
                     .context("Failed to determine token cache file path")?;
 
-            fs::remove_file(&token_cache_path)
-                .context(format!(
-                    "Failed to remove invalid token cache at: {}",
-                    token_cache_path.display()
-                ))?;
+            fs::remove_file(&token_cache_path).context(format!(
+                "Failed to remove invalid token cache at: {}",
+                token_cache_path.display()
+            ))?;
 
             log::info!("Removed cached token at: {}", token_cache_path.display());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // load stored query
     if let Some(query_name) = args.stored_query {
         // Safe to unwrap: validated by validate_for_operation()
-        let query_filename = resolved_config.queries_filename.as_ref().expect("queries_filename validated earlier");
+        let query_filename = resolved_config
+            .queries_filename
+            .as_ref()
+            .expect("queries_filename validated earlier");
         let queries_path = crate::config::config_file_path(query_filename).unwrap();
 
         args.gaql_query = match util::get_queries_from_file(&queries_path).await {
@@ -87,7 +90,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Use OpenAI for LLM
         let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
         // Safe to unwrap: validated by validate_for_operation()
-        let query_filename = resolved_config.queries_filename.as_ref().expect("queries_filename validated earlier");
+        let query_filename = resolved_config
+            .queries_filename
+            .as_ref()
+            .expect("queries_filename validated earlier");
         let queries_path = crate::config::config_file_path(query_filename).unwrap();
 
         let example_queries: Vec<QueryEntry> =

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,8 +116,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let api_context = match googleads::get_api_access(
         mcc_customer_id,
+        &resolved_config.token_cache_filename,
         user_email,
-        resolved_config.token_cache_filename.as_deref(),
     )
     .await
     {
@@ -125,17 +125,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err(_e) => {
             log::info!("Refresh token became invalid. Clearing token cache and forcing re-auth");
             // remove cached token to force re-auth and try again
-            let token_cache_filename = googleads::resolve_token_cache_filename(
-                resolved_config.token_cache_filename.as_deref(),
-                user_email,
-            );
             let token_cache_path =
-                crate::config::config_file_path(&token_cache_filename).expect("token cache path");
+                crate::config::config_file_path(&resolved_config.token_cache_filename)
+                    .expect("token cache path");
             let _ = fs::remove_file(token_cache_path);
             googleads::get_api_access(
                 mcc_customer_id,
+                &resolved_config.token_cache_filename,
                 user_email,
-                resolved_config.token_cache_filename.as_deref(),
             )
             .await
             .expect("Refresh token expired and failed to kick off re-auth.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ mod googleads;
 mod prompt2gaql;
 mod util;
 
-use crate::args::Cli;
 use crate::args::OutputFormat;
 use crate::config::ResolvedConfig;
 use crate::util::QueryEntry;
@@ -39,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = args::parse();
 
     // Validate argument combinations
-    validate_args(&args)?;
+    args.validate()?;
 
     // Only load config if profile is explicitly specified
     let config = if let Some(profile) = &args.profile {
@@ -677,38 +676,4 @@ fn output_dataframe(
     Ok(())
 }
 
-fn validate_args(args: &Cli) -> Result<()> {
-    // Ambiguous which child account(s) to query
-    if args.customer_id.is_some() && args.all_linked_child_accounts {
-        return Err(anyhow::anyhow!(
-            "Use --customer-id to query a specific account.\n\
-                Use --mcc with --all-linked-child-accounts to query all child accounts under mcc.\n\
-                Please don't use --customer-id and --all-linked-child-accounts together."
-        ));
-    }
 
-    // Validate that stored query and natural language aren't both specified
-    if args.stored_query.is_some() && args.natural_language {
-        return Err(anyhow::anyhow!(
-            "Cannot use both --stored-query and --natural-language.\n\
-             Choose one query method."
-        ));
-    }
-
-    // Validate that natural language requires a query text
-    if args.natural_language && args.gaql_query.is_none() {
-        return Err(anyhow::anyhow!(
-            "Natural language mode requires a query string.\n\
-             Usage: mcc-gaql --natural-language \"show me all campaigns\""
-        ));
-    }
-
-    // Warn if both profile and config-free mode arguments are mixed
-    if args.profile.is_some() && args.mcc.is_some() {
-        log::warn!(
-            "Both --profile and --mcc specified. CLI --mcc will override profile's MCC setting."
-        );
-    }
-
-    Ok(())
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,15 +19,11 @@ use polars::prelude::*;
 use thousands::Separable;
 use tonic::{codegen::InterceptedService, transport::Channel};
 
-mod args;
-mod config;
-mod googleads;
-mod prompt2gaql;
-mod util;
-
-use crate::args::OutputFormat;
-use crate::config::ResolvedConfig;
-use crate::util::QueryEntry;
+use mcc_gaql::args::{self, OutputFormat};
+use mcc_gaql::config::{self, ResolvedConfig};
+use mcc_gaql::googleads;
+use mcc_gaql::prompt2gaql;
+use mcc_gaql::util::{self, QueryEntry};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -67,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .queries_filename
             .as_ref()
             .expect("queries_filename validated earlier");
-        let queries_path = crate::config::config_file_path(query_filename).unwrap();
+        let queries_path = mcc_gaql::config::config_file_path(query_filename).unwrap();
 
         args.gaql_query = match util::get_queries_from_file(&queries_path).await {
             Ok(map) => {
@@ -94,7 +90,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .queries_filename
             .as_ref()
             .expect("queries_filename validated earlier");
-        let queries_path = crate::config::config_file_path(query_filename).unwrap();
+        let queries_path = mcc_gaql::config::config_file_path(query_filename).unwrap();
 
         let example_queries: Vec<QueryEntry> =
             match util::get_queries_from_file(&queries_path).await {
@@ -138,7 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             log::info!("Refresh token became invalid. Clearing token cache and forcing re-auth");
             // remove cached token to force re-auth and try again
             let token_cache_path =
-                crate::config::config_file_path(&resolved_config.token_cache_filename)
+                mcc_gaql::config::config_file_path(&resolved_config.token_cache_filename)
                     .expect("token cache path");
             let _ = fs::remove_file(token_cache_path);
             googleads::get_api_access(
@@ -224,7 +220,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             else if args.customer_id.is_none() & !args.all_linked_child_accounts {
                 if let Some(customerids_filename) = resolved_config.customerids_filename.as_deref() {
                     let customerids_path =
-                        crate::config::config_file_path(customerids_filename).unwrap();
+                        mcc_gaql::config::config_file_path(customerids_filename).unwrap();
                     log::debug!("Querying accounts listed in file: {}", customerids_path.display());
 
                     (util::get_child_account_ids_from_file(customerids_path.as_path()).await).ok()

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -21,8 +21,10 @@ fn test_mcc_priority_cli_overrides_config() {
 fn test_mcc_fallback_to_customer_id_for_solo_accounts() {
     let args = Cli::parse_from([
         "mcc-gaql",
-        "--customer-id", "2222222222",
-        "--user", "test@example.com"
+        "--customer-id",
+        "2222222222",
+        "--user",
+        "test@example.com",
     ]);
 
     let resolved = ResolvedConfig::from_args_and_config(&args, None).unwrap();
@@ -35,15 +37,22 @@ fn test_error_when_no_mcc_available() {
 
     let result = ResolvedConfig::from_args_and_config(&args, None);
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("MCC customer ID required"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("MCC customer ID required")
+    );
 }
 
 #[test]
 fn test_token_cache_generation_from_user_email() {
     let args = Cli::parse_from([
         "mcc-gaql",
-        "--user", "john.doe@example.com",
-        "--mcc", "1234567890"
+        "--user",
+        "john.doe@example.com",
+        "--mcc",
+        "1234567890",
     ]);
 
     let resolved = ResolvedConfig::from_args_and_config(&args, None).unwrap();
@@ -57,9 +66,11 @@ fn test_token_cache_generation_from_user_email() {
 fn test_validate_requires_user_context() {
     let args = Cli::parse_from([
         "mcc-gaql",
-        "--mcc", "1234567890",
-        "--customer-id", "7890123456",
-        "SELECT campaign.id FROM campaign"
+        "--mcc",
+        "1234567890",
+        "--customer-id",
+        "7890123456",
+        "SELECT campaign.id FROM campaign",
     ]);
 
     let resolved = ResolvedConfig {
@@ -72,5 +83,10 @@ fn test_validate_requires_user_context() {
 
     let result = resolved.validate_for_operation(&args);
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("User context required"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("User context required")
+    );
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -4,9 +4,9 @@ use mcc_gaql::config::{MyConfig, ResolvedConfig};
 
 #[test]
 fn test_mcc_priority_cli_overrides_config() {
-    let args = Cli::parse_from(["mcc-gaql", "--mcc", "111111"]);
+    let args = Cli::parse_from(["mcc-gaql", "--mcc", "1111111111"]);
     let config = Some(MyConfig {
-        mcc_customerid: "999999".to_string(),
+        mcc_customerid: "9999999999".to_string(),
         user: None,
         token_cache_filename: None,
         customerids_filename: None,
@@ -14,19 +14,19 @@ fn test_mcc_priority_cli_overrides_config() {
     });
 
     let resolved = ResolvedConfig::from_args_and_config(&args, config).unwrap();
-    assert_eq!(resolved.mcc_customer_id, "111111");
+    assert_eq!(resolved.mcc_customer_id, "1111111111");
 }
 
 #[test]
 fn test_mcc_fallback_to_customer_id_for_solo_accounts() {
     let args = Cli::parse_from([
         "mcc-gaql",
-        "--customer-id", "222222",
+        "--customer-id", "2222222222",
         "--user", "test@example.com"
     ]);
 
     let resolved = ResolvedConfig::from_args_and_config(&args, None).unwrap();
-    assert_eq!(resolved.mcc_customer_id, "222222");
+    assert_eq!(resolved.mcc_customer_id, "2222222222");
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn test_token_cache_generation_from_user_email() {
     let args = Cli::parse_from([
         "mcc-gaql",
         "--user", "john.doe@example.com",
-        "--mcc", "123456"
+        "--mcc", "1234567890"
     ]);
 
     let resolved = ResolvedConfig::from_args_and_config(&args, None).unwrap();
@@ -57,13 +57,13 @@ fn test_token_cache_generation_from_user_email() {
 fn test_validate_requires_user_context() {
     let args = Cli::parse_from([
         "mcc-gaql",
-        "--mcc", "123456",
-        "--customer-id", "789012",
+        "--mcc", "1234567890",
+        "--customer-id", "7890123456",
         "SELECT campaign.id FROM campaign"
     ]);
 
     let resolved = ResolvedConfig {
-        mcc_customer_id: "123456".to_string(),
+        mcc_customer_id: "1234567890".to_string(),
         user_email: None, // Missing user
         token_cache_filename: "tokencache_default.json".to_string(),
         queries_filename: None,

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,0 +1,76 @@
+use clap::Parser;
+use mcc_gaql::args::Cli;
+use mcc_gaql::config::{MyConfig, ResolvedConfig};
+
+#[test]
+fn test_mcc_priority_cli_overrides_config() {
+    let args = Cli::parse_from(["mcc-gaql", "--mcc", "111111"]);
+    let config = Some(MyConfig {
+        mcc_customerid: "999999".to_string(),
+        user: None,
+        token_cache_filename: None,
+        customerids_filename: None,
+        queries_filename: None,
+    });
+
+    let resolved = ResolvedConfig::from_args_and_config(&args, config).unwrap();
+    assert_eq!(resolved.mcc_customer_id, "111111");
+}
+
+#[test]
+fn test_mcc_fallback_to_customer_id_for_solo_accounts() {
+    let args = Cli::parse_from([
+        "mcc-gaql",
+        "--customer-id", "222222",
+        "--user", "test@example.com"
+    ]);
+
+    let resolved = ResolvedConfig::from_args_and_config(&args, None).unwrap();
+    assert_eq!(resolved.mcc_customer_id, "222222");
+}
+
+#[test]
+fn test_error_when_no_mcc_available() {
+    let args = Cli::parse_from(["mcc-gaql", "--user", "test@example.com"]);
+
+    let result = ResolvedConfig::from_args_and_config(&args, None);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("MCC customer ID required"));
+}
+
+#[test]
+fn test_token_cache_generation_from_user_email() {
+    let args = Cli::parse_from([
+        "mcc-gaql",
+        "--user", "john.doe@example.com",
+        "--mcc", "123456"
+    ]);
+
+    let resolved = ResolvedConfig::from_args_and_config(&args, None).unwrap();
+    assert_eq!(
+        resolved.token_cache_filename,
+        "tokencache_john_doe_at_example_com.json"
+    );
+}
+
+#[test]
+fn test_validate_requires_user_context() {
+    let args = Cli::parse_from([
+        "mcc-gaql",
+        "--mcc", "123456",
+        "--customer-id", "789012",
+        "SELECT campaign.id FROM campaign"
+    ]);
+
+    let resolved = ResolvedConfig {
+        mcc_customer_id: "123456".to_string(),
+        user_email: None, // Missing user
+        token_cache_filename: "tokencache_default.json".to_string(),
+        queries_filename: None,
+        customerids_filename: None,
+    };
+
+    let result = resolved.validate_for_operation(&args);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("User context required"));
+}


### PR DESCRIPTION
Enable config-free mode by making all configuration optional and removing the automatic fallback to "test" profile. Users can now run queries using only CLI arguments without requiring a config file.

Key changes:
- Add --user flag to specify OAuth email (auto-generates token cache)
- Add --mcc flag to specify MCC customer ID via CLI
- Remove default "test" profile - profile must be explicitly specified
- Use --customer-id as MCC when no --mcc or profile provided
- Make config loading conditional on --profile flag
- Update all config references to handle Option<MyConfig>
- Add clear error messages when information is missing

Config-free usage:
  mcc-gaql -c 3902228771 "GAQL QUERY" --user user@example.com

Profile-based usage (backward compatible):
  mcc-gaql --profile test -q all_campaigns

Fixes issue where --user was ignored and wrong profile credentials were used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)