### PR TITLE
Claude/skip vector tests 011 cv1s ejagq9 rb q jpwgzvmw

### DIFF
--- a/tests/field_vector_store_rag_tests.rs
+++ b/tests/field_vector_store_rag_tests.rs
@@ -219,6 +219,7 @@ impl RetrievalTestCase {
 }
 
 #[tokio::test]
+#[ignore = "Requires field metadata cache - run tool first to populate cache"]
 async fn test_field_retrieval_for_cost_metrics() {
     RetrievalTestCase::new(
         "cost per click and average cost metrics",
@@ -239,6 +240,7 @@ async fn test_field_retrieval_for_cost_metrics() {
 }
 
 #[tokio::test]
+#[ignore = "Requires field metadata cache - run tool first to populate cache"]
 async fn test_field_retrieval_for_conversions() {
     RetrievalTestCase::new(
         "metrics for conversions and conversion rate",
@@ -259,6 +261,7 @@ async fn test_field_retrieval_for_conversions() {
 }
 
 #[tokio::test]
+#[ignore = "Requires field metadata cache - run tool first to populate cache"]
 async fn test_field_retrieval_for_impressions_and_clicks() {
     RetrievalTestCase::new(
         "impressions, clicks, and interactions metrics",
@@ -277,6 +280,7 @@ async fn test_field_retrieval_for_impressions_and_clicks() {
 }
 
 #[tokio::test]
+#[ignore = "Requires field metadata cache - run tool first to populate cache"]
 async fn test_field_retrieval_for_impression_share_metrics() {
     RetrievalTestCase::new(
         "impression share metrics",
@@ -299,6 +303,7 @@ async fn test_field_retrieval_for_impression_share_metrics() {
 }
 
 #[tokio::test]
+#[ignore = "Requires field metadata cache - run tool first to populate cache"]
 async fn test_field_retrieval_similarity_scores() {
     // This test validates that similarity scores are reasonable
     let vector_store = get_test_field_vector_store()
@@ -362,6 +367,7 @@ async fn test_field_retrieval_similarity_scores() {
 }
 
 #[tokio::test]
+#[ignore = "Requires field metadata cache - run tool first to populate cache"]
 async fn test_field_retrieval_ranking() {
     // This test ensures more relevant fields rank higher
     let vector_store = get_test_field_vector_store()
@@ -414,6 +420,7 @@ async fn test_field_retrieval_ranking() {
 }
 
 #[tokio::test]
+#[ignore = "Requires field metadata cache - run tool first to populate cache"]
 async fn test_field_retrieval_negative_case() {
     // Test that unrelated queries don't return extremely high scores
     let vector_store = get_test_field_vector_store()
@@ -449,6 +456,7 @@ async fn test_field_retrieval_negative_case() {
 }
 
 #[tokio::test]
+#[ignore = "Requires field metadata cache - run tool first to populate cache"]
 async fn test_field_description_quality() {
     // Test that field descriptions are being generated properly
     let cache_path =
@@ -497,6 +505,7 @@ async fn test_field_description_quality() {
 }
 
 #[tokio::test]
+#[ignore = "Requires field metadata cache - run tool first to populate cache"]
 async fn test_category_specific_retrieval() {
     // Test retrieval for different categories
     let vector_store = get_test_field_vector_store()


### PR DESCRIPTION
## Summary

This PR adds `#[ignore]` attributes to vector store integration tests that require cached field metadata, allowing them to be skipped in GitHub Actions CI where the cache is not available.

## Changes

### Modified Files
- `tests/field_vector_store_rag_tests.rs`: Added `#[ignore]` attribute to 9 integration tests

### Tests Marked as Ignored
All tests now have `#[ignore = "Requires field metadata cache - run tool first to populate cache"]`:

1. `test_field_retrieval_for_cost_metrics`
2. `test_field_retrieval_for_conversions`
3. `test_field_retrieval_for_impressions_and_clicks`
4. `test_field_retrieval_for_impression_share_metrics`
5. `test_field_retrieval_similarity_scores`
6. `test_field_retrieval_ranking`
7. `test_field_retrieval_negative_case`
8. `test_field_description_quality`
9. `test_category_specific_retrieval`

## Why This Change?

These integration tests depend on pre-populated field metadata cache that is generated by running the `mcc-gaql` tool locally with valid Google Ads API credentials. This cache cannot be created in the GitHub Actions CI environment, causing test failures.

## Impact

- ✅ **CI/CD:** Tests will be skipped automatically during `cargo test` in GitHub Actions
- ✅ **Local Development:** Tests can still be run with `cargo test -- --ignored` or `cargo test -- --include-ignored`
- ✅ **Other Tests:** The `minimal_rag_test.rs` continues to run in CI as it creates its own test data

## Testing

Tests can be verified locally with:
```bash
# Run only the ignored tests
cargo test -- --ignored

# Run all tests including ignored ones
cargo test -- --include-ignored