### PR TITLE
Add configurable LLM provider support

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -21,7 +21,8 @@ jobs:
 
           # Optional inputs with defaults
           # model_id: 'openai/gpt-4o-mini' # Cheap and Fast
-          model_id: 'anthropic/claude-sonnet-4.5' # Catch nuanced bugs
+          # model_id: 'anthropic/claude-sonnet-4.5' # Catch nuanced bugs
+          model_id: 'z-ai/glm-4.7' # Cheap but goood
           max_tokens: '2048' # Default max tokens
           review_label: 'ai-review' # Optional: Only review PRs with this label
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mcc-gaql"
 description = "Execute GAQL across MCC child accounts."
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Michael S. Huang <mhuang74@gmail.com>"]
 edition = "2024"
 
@@ -12,7 +12,7 @@ anyhow = "1.0"
 async-std = "1.11"
 bincode = "1.3"
 cacache = "10.0"
-chrono = "0.4"
+chrono = "0.4.42"
 clap = { version = "3.1", features = ["derive", "cargo"] }
 dialoguer = "0.11"
 dirs = "4.0"
@@ -34,10 +34,10 @@ toml = "0.5"
 tonic = { version = "0.14", features = ["transport", "tls-ring", "tls-native-roots"] }
 serde_json = "1.0"
 yup-oauth2 = "6.7"
-rig-core = "0.24.0"
-rig-fastembed = "0.2.16"
-rig-lancedb = "0.2.27"
-lancedb = "0.22"
+rig-core = "0.29"
+rig-fastembed = "0.2.21"
+rig-lancedb = "0.2.32"
+lancedb = "0.23"
 arrow-array = "56.2.0"
 arrow-schema = "56.2.0"
 

--- a/specs/configurable-llm-provider.md
+++ b/specs/configurable-llm-provider.md
@@ -1,0 +1,326 @@
+# Configurable LLM Provider Specification
+
+**Status:** Proposed
+**Author:** System Design
+**Date:** 2026-02-03
+**Related Docs:**
+- specs/embedding-model-switching.md
+
+---
+
+## Summary
+
+Replace the hardcoded OpenRouter/Gemini Flash LLM configuration with a configurable provider system that supports OpenAI-compatible APIs, including Nano-gpt.com.
+
+---
+
+## Current State
+
+The LLM provider is hardcoded in `src/prompt2gaql.rs`:
+
+```rust
+// Lines 532, 659-663
+let openrouter_client = openrouter::Client::from_env();
+let agent = openrouter_client
+    .agent(openrouter::GEMINI_FLASH_2_0)
+    .preamble(&preamble)
+    .temperature(0.1)
+    .build();
+```
+
+**Problems:**
+- Cannot switch providers without code changes
+- Cannot use Nano-gpt.com or other OpenAI-compatible providers
+- Requires `OPENROUTER_API_KEY` even if user prefers different provider
+
+---
+
+## Proposed Solution
+
+Use Rig's OpenAI provider with custom `base_url` to support any OpenAI-compatible API.
+
+### API Design
+
+Rig's OpenAI `ClientBuilder` supports custom base URLs:
+
+```rust
+use rig::providers::openai;
+
+let client = openai::ClientBuilder::new(&api_key)
+    .base_url("https://nano-gpt.com/api/v1")
+    .build();
+
+let agent = client
+    .agent("glm-4-9b")
+    .preamble(&preamble)
+    .temperature(0.1)
+    .build();
+```
+
+### Configuration
+
+**Environment Variables:**
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `MCC_GAQL_LLM_API_KEY` | API key for the LLM provider | `your-nano-gpt-key` |
+| `MCC_GAQL_LLM_BASE_URL` | Base URL for OpenAI-compatible API | `https://nano-gpt.com/api/v1` |
+| `MCC_GAQL_LLM_MODEL` | Model name | `glm-4-9b` |
+| `MCC_GAQL_LLM_TEMPERATURE` | Temperature (optional, default: 0.1) | `0.1` |
+
+**Backward Compatibility:**
+
+For backward compatibility with existing setups:
+- If `MCC_GAQL_LLM_API_KEY` is not set, fall back to `OPENROUTER_API_KEY`
+- If `MCC_GAQL_LLM_BASE_URL` is not set, use OpenRouter's default URL
+- If `MCC_GAQL_LLM_MODEL` is not set, use `google/gemini-flash-2.0`
+
+### Provider Presets
+
+Common providers with their base URLs:
+
+| Provider | Base URL | Example Models |
+|----------|----------|----------------|
+| OpenRouter | `https://openrouter.ai/api/v1` | `google/gemini-flash-2.0`, `anthropic/claude-3.5-sonnet` |
+| Nano-gpt | `https://nano-gpt.com/api/v1` | `glm-4-9b`, `glm-4-plus` |
+| OpenAI | `https://api.openai.com/v1` | `gpt-4o`, `gpt-4-turbo` |
+| Ollama | `http://localhost:11434/v1` | `llama3.1`, `mistral` |
+
+---
+
+## Implementation
+
+### File Changes
+
+**`src/prompt2gaql.rs`:**
+
+```rust
+use rig::providers::openai;
+
+/// Load LLM configuration from environment
+fn load_llm_config() -> (String, String, String, f32) {
+    // API key: prefer MCC_GAQL_LLM_API_KEY, fall back to OPENROUTER_API_KEY
+    let api_key = std::env::var("MCC_GAQL_LLM_API_KEY")
+        .or_else(|_| std::env::var("OPENROUTER_API_KEY"))
+        .expect("MCC_GAQL_LLM_API_KEY or OPENROUTER_API_KEY must be set");
+
+    // Base URL: default to OpenRouter for backward compatibility
+    let base_url = std::env::var("MCC_GAQL_LLM_BASE_URL")
+        .unwrap_or_else(|_| "https://openrouter.ai/api/v1".to_string());
+
+    // Model: default to Gemini Flash
+    let model = std::env::var("MCC_GAQL_LLM_MODEL")
+        .unwrap_or_else(|_| "google/gemini-flash-2.0".to_string());
+
+    // Temperature
+    let temperature: f32 = std::env::var("MCC_GAQL_LLM_TEMPERATURE")
+        .ok()
+        .and_then(|t| t.parse().ok())
+        .unwrap_or(0.1);
+
+    (api_key, base_url, model, temperature)
+}
+
+/// Create LLM client with configurable provider
+fn create_llm_client() -> openai::Client {
+    let (api_key, base_url, _, _) = load_llm_config();
+
+    openai::ClientBuilder::new(&api_key)
+        .base_url(&base_url)
+        .build()
+}
+```
+
+**Update `RAGAgent::init()` (line ~524):**
+
+```rust
+impl RAGAgent {
+    pub async fn init(query_cookbook: Vec<QueryEntry>) -> Result<Self, anyhow::Error> {
+        let (api_key, base_url, model, temperature) = load_llm_config();
+
+        log::info!("Using LLM: {} via {}", model, base_url);
+
+        let llm_client = openai::ClientBuilder::new(&api_key)
+            .base_url(&base_url)
+            .build();
+
+        // ... existing embedding setup ...
+
+        let agent = llm_client
+            .agent(&model)
+            .preamble("...")
+            .temperature(temperature)
+            .build();
+
+        Ok(RAGAgent { agent, query_index })
+    }
+}
+```
+
+**Update `EnhancedRAGAgent::init()` (line ~627):**
+
+Same pattern as above.
+
+**`src/main.rs`:**
+
+Update the environment variable check:
+
+```rust
+// Old (line ~209):
+// env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY not set");
+
+// New:
+if std::env::var("MCC_GAQL_LLM_API_KEY").is_err() && std::env::var("OPENROUTER_API_KEY").is_err() {
+    panic!("Either MCC_GAQL_LLM_API_KEY or OPENROUTER_API_KEY must be set");
+}
+```
+
+### Cargo.toml
+
+No changes needed - `rig-core` already includes the OpenAI provider.
+
+---
+
+## Usage Examples
+
+### Example 1: Nano-gpt with GLM-4
+
+```bash
+export MCC_GAQL_LLM_API_KEY="your-nano-gpt-key"
+export MCC_GAQL_LLM_BASE_URL="https://nano-gpt.com/api/v1"
+export MCC_GAQL_LLM_MODEL="glm-4-9b"
+
+mcc-gaql -n "show me campaigns with high CTR"
+```
+
+### Example 2: OpenRouter (backward compatible)
+
+```bash
+# Works exactly as before
+export OPENROUTER_API_KEY="your-openrouter-key"
+mcc-gaql -n "show me campaigns"
+```
+
+### Example 3: Local Ollama
+
+```bash
+export MCC_GAQL_LLM_BASE_URL="http://localhost:11434/v1"
+export MCC_GAQL_LLM_MODEL="llama3.1"
+export MCC_GAQL_LLM_API_KEY="ollama"  # Ollama ignores this but rig requires it
+
+mcc-gaql -n "show me campaigns"
+```
+
+### Example 4: One-time override
+
+```bash
+# Use Claude via OpenRouter just for this query
+MCC_GAQL_LLM_MODEL="anthropic/claude-3.5-sonnet" mcc-gaql -n "complex query"
+```
+
+---
+
+## Testing
+
+### Unit Tests
+
+```rust
+#[test]
+fn test_load_llm_config_defaults() {
+    std::env::set_var("OPENROUTER_API_KEY", "test-key");
+    std::env::remove_var("MCC_GAQL_LLM_API_KEY");
+    std::env::remove_var("MCC_GAQL_LLM_BASE_URL");
+    std::env::remove_var("MCC_GAQL_LLM_MODEL");
+
+    let (api_key, base_url, model, temp) = load_llm_config();
+
+    assert_eq!(api_key, "test-key");
+    assert_eq!(base_url, "https://openrouter.ai/api/v1");
+    assert_eq!(model, "google/gemini-flash-2.0");
+    assert_eq!(temp, 0.1);
+}
+
+#[test]
+fn test_load_llm_config_custom() {
+    std::env::set_var("MCC_GAQL_LLM_API_KEY", "nano-key");
+    std::env::set_var("MCC_GAQL_LLM_BASE_URL", "https://nano-gpt.com/api/v1");
+    std::env::set_var("MCC_GAQL_LLM_MODEL", "glm-4-9b");
+    std::env::set_var("MCC_GAQL_LLM_TEMPERATURE", "0.2");
+
+    let (api_key, base_url, model, temp) = load_llm_config();
+
+    assert_eq!(api_key, "nano-key");
+    assert_eq!(base_url, "https://nano-gpt.com/api/v1");
+    assert_eq!(model, "glm-4-9b");
+    assert_eq!(temp, 0.2);
+}
+```
+
+### Integration Test
+
+```rust
+#[tokio::test]
+#[ignore]  // Requires real API key
+async fn test_nano_gpt_integration() {
+    std::env::set_var("MCC_GAQL_LLM_API_KEY", std::env::var("NANO_GPT_API_KEY").unwrap());
+    std::env::set_var("MCC_GAQL_LLM_BASE_URL", "https://nano-gpt.com/api/v1");
+    std::env::set_var("MCC_GAQL_LLM_MODEL", "glm-4-9b");
+
+    let result = convert_to_gaql_enhanced(
+        vec![],  // empty cookbook for test
+        None,
+        "show all campaigns"
+    ).await;
+
+    assert!(result.is_ok());
+    let query = result.unwrap();
+    assert!(query.to_uppercase().contains("SELECT"));
+    assert!(query.to_uppercase().contains("FROM CAMPAIGN"));
+}
+```
+
+---
+
+## Migration
+
+1. **No breaking changes** - existing `OPENROUTER_API_KEY` setups continue to work
+2. **Gradual adoption** - users can switch to new env vars when ready
+3. **Documentation** - update README with new configuration options
+
+---
+
+## Verification
+
+After implementation, verify with:
+
+```bash
+# 1. Backward compatibility (should work unchanged)
+OPENROUTER_API_KEY="..." mcc-gaql -n "show campaigns"
+
+# 2. Nano-gpt integration
+MCC_GAQL_LLM_API_KEY="..." \
+MCC_GAQL_LLM_BASE_URL="https://nano-gpt.com/api/v1" \
+MCC_GAQL_LLM_MODEL="glm-4-9b" \
+mcc-gaql -n "show campaigns"
+
+# 3. Check logs show correct provider
+RUST_LOG=info mcc-gaql -n "show campaigns"
+# Should log: "Using LLM: glm-4-9b via https://nano-gpt.com/api/v1"
+```
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/prompt2gaql.rs` | Add `load_llm_config()`, update `RAGAgent::init()` and `EnhancedRAGAgent::init()` |
+| `src/main.rs` | Update API key validation |
+
+---
+
+## Future Enhancements
+
+1. **Config file support** - Add `[llm]` section to `~/.config/mcc-gaql/config.toml`
+2. **Provider presets** - `LLM_PROVIDER=nano-gpt` auto-sets base_url
+3. **Model aliases** - Short names like `glm4` -> `glm-4-9b`

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 //
 
 use std::{
-    env,
     fs::{self, File},
     io::{BufWriter, Write},
     process,
@@ -205,8 +204,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // convert natural language prompt into GAQL
     if args.natural_language {
-        // Use OpenRouter for LLM (API key loaded from environment)
-        env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY not set");
+        // Validate LLM API key is configured (supports multiple providers)
+        if std::env::var("MCC_GAQL_LLM_API_KEY").is_err()
+            && std::env::var("OPENROUTER_API_KEY").is_err()
+        {
+            panic!("Either MCC_GAQL_LLM_API_KEY or OPENROUTER_API_KEY must be set");
+        }
         // Safe to unwrap: validated by validate_for_operation()
         let query_filename = resolved_config
             .queries_filename

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,13 +261,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let prompt = args.gaql_query.as_ref().unwrap();
         log::debug!("Construct GAQL from prompt: {:?}", prompt);
 
+        // Load LLM configuration once and pass to agents (dependency injection)
+        let llm_config = prompt2gaql::LlmConfig::from_env();
+
         // Use enhanced conversion with field metadata if available
         let query = if field_cache.is_some() {
             log::info!("Using enhanced natural query with field metadata");
-            prompt2gaql::convert_to_gaql_enhanced(example_queries, field_cache, prompt).await?
+            prompt2gaql::convert_to_gaql_enhanced(example_queries, field_cache, prompt, &llm_config)
+                .await?
         } else {
             log::info!("Using basic natural query without field metadata");
-            prompt2gaql::convert_to_gaql(example_queries, prompt).await?
+            prompt2gaql::convert_to_gaql(example_queries, prompt, &llm_config).await?
         };
 
         log::info!("Generated GAQL Query:\n{}", query);

--- a/src/prompt2gaql.rs
+++ b/src/prompt2gaql.rs
@@ -48,9 +48,12 @@ impl LlmConfig {
 
         // Temperature: default to 0.1 if not set, fail fast with explicit error if invalid
         let temperature: f32 = match std::env::var("MCC_GAQL_LLM_TEMPERATURE") {
-            Ok(val) => val.parse().expect(
-                &format!("MCC_GAQL_LLM_TEMPERATURE must be a valid number (e.g., 0.1), got: '{}'", val)
-            ),
+            Ok(val) => val.parse().unwrap_or_else(|_| {
+                panic!(
+                    "MCC_GAQL_LLM_TEMPERATURE must be a valid number (e.g., 0.1), got: '{}'",
+                    val
+                )
+            }),
             Err(_) => 0.1,
         };
 
@@ -735,11 +738,9 @@ impl EnhancedRAGAgent {
             "Initializing query cookbook embeddings for {} queries",
             query_cookbook.len()
         );
-        let query_index = build_or_load_query_vector_store(
-            query_cookbook,
-            resources.embedding_model.clone(),
-        )
-        .await?;
+        let query_index =
+            build_or_load_query_vector_store(query_cookbook, resources.embedding_model.clone())
+                .await?;
 
         // Build or load field embeddings if field cache is available
         let field_vector_store = if let Some(ref cache) = field_cache {
@@ -747,9 +748,7 @@ impl EnhancedRAGAgent {
                 "Initializing field embeddings for {} fields",
                 cache.fields.len()
             );
-            Some(
-                build_or_load_field_vector_store(cache, resources.embedding_model.clone()).await?,
-            )
+            Some(build_or_load_field_vector_store(cache, resources.embedding_model.clone()).await?)
         } else {
             None
         };

--- a/src/prompt2gaql.rs
+++ b/src/prompt2gaql.rs
@@ -42,8 +42,9 @@ impl LlmConfig {
             .expect("MCC_GAQL_LLM_BASE_URL must be set (e.g., https://api.openai.com/v1 or https://openrouter.ai/api/v1)");
 
         // Model: must be explicitly configured - fail fast if not set
-        let model = std::env::var("MCC_GAQL_LLM_MODEL")
-            .expect("MCC_GAQL_LLM_MODEL must be set (e.g., gpt-4o-mini or google/gemini-flash-2.0)");
+        let model = std::env::var("MCC_GAQL_LLM_MODEL").expect(
+            "MCC_GAQL_LLM_MODEL must be set (e.g., gpt-4o-mini or google/gemini-flash-2.0)",
+        );
 
         // Temperature: default to 0.1 if not set
         let temperature: f32 = std::env::var("MCC_GAQL_LLM_TEMPERATURE")

--- a/src/prompt2gaql.rs
+++ b/src/prompt2gaql.rs
@@ -32,10 +32,9 @@ pub struct LlmConfig {
 impl LlmConfig {
     /// Load LLM configuration from environment
     pub fn from_env() -> Self {
-        // API key: prefer MCC_GAQL_LLM_API_KEY, fall back to OPENROUTER_API_KEY for backward compatibility
+        // API key: must be explicitly configured
         let api_key = std::env::var("MCC_GAQL_LLM_API_KEY")
-            .or_else(|_| std::env::var("OPENROUTER_API_KEY"))
-            .expect("MCC_GAQL_LLM_API_KEY or OPENROUTER_API_KEY must be set");
+            .expect("MCC_GAQL_LLM_API_KEY must be set (e.g., sk-...)");
 
         // Base URL: must be explicitly configured - fail fast if not set
         let base_url = std::env::var("MCC_GAQL_LLM_BASE_URL")


### PR DESCRIPTION
## Summary
Replace the hardcoded OpenRouter LLM configuration with a configurable provider system supporting any OpenAI-compatible API (Nano-gpt.com, Ollama, OpenAI, etc.).

## Changes
- Use `rig-core` 0.29 `CompletionsClient` with custom `base_url`
- Add `load_llm_config()` to read from environment variables
- Update `RAGAgent` and `EnhancedRAGAgent` to use configurable provider
- Support `MCC_GAQL_LLM_*` env vars with fallback to `OPENROUTER_API_KEY`
- Upgrade dependencies: rig-core 0.29, rig-fastembed 0.2.21, rig-lancedb 0.2.32, lancedb 0.23

## Environment Variables
| Variable | Description | Default |
|----------|-------------|---------|
| `MCC_GAQL_LLM_API_KEY` | API key for LLM provider | Error |
| `MCC_GAQL_LLM_BASE_URL` | Base URL for OpenAI-compatible API | Error |
| `MCC_GAQL_LLM_MODEL` | Model name | Error |
| `MCC_GAQL_LLM_TEMPERATURE` | Temperature | `0.1` |

## Provider Examples
| Provider | Base URL | Example Model |
|----------|----------|---------------|
| OpenRouter | `https://openrouter.ai/api/v1` | `z-ai/glm-4.7-flash` |
| Nano-gpt | `https://nano-gpt.com/api/v1` | `zai-org/glm-4.7-flash` |
| OpenAI | `https://api.openai.com/v1` | `gpt-4o-mini` |
| Ollama | `http://localhost:11434/v1` | `llama3.1` |

## Backward Compatibility
This is a breaking change. Setups need to stop using `OPENROUTER_API_KEY` and define all the new env vars for API Key, Base URL, and Model Name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)