### PR TITLE
Migrate from Google Ads API v22 to v23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ figment = { version = "0.10", features = ["toml", "env"] }
 flexi_logger = { version = "0.22", features = ["compress"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 # googleads-rs = { version = "0.12.1", path = "../googleads-rs" }
-# googleads-rs = { git = "https://github.com/mhuang74/googleads-rs.git", branch = "main" }
-googleads-rs = { version = "0.12" }
+googleads-rs = { version = "0.13.0", git = "https://github.com/mhuang74/googleads-rs.git", branch = "main" }
+# googleads-rs = { version = "0.12" }
 itertools = "0.10"
 log = "0.4"
 polars = { version = "0.42", features = ["lazy", "serde-lazy"] }

--- a/src/field_metadata.rs
+++ b/src/field_metadata.rs
@@ -11,8 +11,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
-use googleads_rs::google::ads::googleads::v22::services::SearchGoogleAdsFieldsRequest;
-use googleads_rs::google::ads::googleads::v22::services::google_ads_field_service_client::GoogleAdsFieldServiceClient;
+use googleads_rs::google::ads::googleads::v23::services::SearchGoogleAdsFieldsRequest;
+use googleads_rs::google::ads::googleads::v23::services::google_ads_field_service_client::GoogleAdsFieldServiceClient;
 
 use crate::googleads::GoogleAdsAPIAccess;
 
@@ -78,7 +78,7 @@ impl FieldMetadataCache {
     pub fn new() -> Self {
         Self {
             last_updated: Utc::now(),
-            api_version: "v22".to_string(),
+            api_version: "v23".to_string(),
             fields: HashMap::new(),
             resources: None,
         }
@@ -226,7 +226,7 @@ impl FieldMetadataCache {
 
         Ok(Self {
             last_updated: Utc::now(),
-            api_version: "v22".to_string(),
+            api_version: "v23".to_string(),
             fields,
             resources: Some(resources),
         })

--- a/src/googleads.rs
+++ b/src/googleads.rs
@@ -15,9 +15,9 @@ use yup_oauth2::{
     authenticator::{Authenticator, DefaultHyperClient, HyperClientBuilder},
 };
 
-use googleads_rs::google::ads::googleads::v22::services::google_ads_field_service_client::GoogleAdsFieldServiceClient;
-use googleads_rs::google::ads::googleads::v22::services::google_ads_service_client::GoogleAdsServiceClient;
-use googleads_rs::google::ads::googleads::v22::services::{
+use googleads_rs::google::ads::googleads::v23::services::google_ads_field_service_client::GoogleAdsFieldServiceClient;
+use googleads_rs::google::ads::googleads::v23::services::google_ads_service_client::GoogleAdsServiceClient;
+use googleads_rs::google::ads::googleads::v23::services::{
     GoogleAdsRow, SearchGoogleAdsFieldsRequest, SearchGoogleAdsFieldsResponse,
     SearchGoogleAdsStreamRequest, SearchGoogleAdsStreamResponse,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 use futures::{StreamExt, stream::FuturesUnordered};
 
 use googleads::GoogleAdsAPIAccess;
-use googleads_rs::google::ads::googleads::v22::services::google_ads_service_client::GoogleAdsServiceClient;
+use googleads_rs::google::ads::googleads::v23::services::google_ads_service_client::GoogleAdsServiceClient;
 use polars::prelude::*;
 use thousands::Separable;
 use tonic::{codegen::InterceptedService, transport::Channel};


### PR DESCRIPTION
## Summary
Upgrades the Google Ads API integration from v22 to v23.

## Changes
| File | Change |
|------|--------|
| `Cargo.toml` | Updated `googleads-rs` dependency from `0.12` to `0.13.0` |
| `src/googleads.rs` | Changed imports from `v22::services::*` to `v23::services::*` |
| `src/field_metadata.rs` | Changed imports and updated `api_version` string from `"v22"` to `"v23"` |
| `src/main.rs` | Changed import from `v22::services::*` to `v23::services::*` |

**Total:** 4 files changed, 10 insertions(+), 10 deletions(-)

## Verification
- [x] Code compiles successfully
- [x] All imports updated to v23
- [x] API version strings updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)