### PR TITLE
Add --clear-vector-cache flag and fix embedding dimension mismatch

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -109,6 +109,10 @@ pub struct Cli {
     #[clap(long)]
     pub refresh_field_cache: bool,
 
+    /// Clear the vector cache (LanceDB embeddings) and exit
+    #[clap(long)]
+    pub clear_vector_cache: bool,
+
     /// Show available fields for a specific resource (e.g., campaign, ad_group)
     #[clap(long)]
     pub show_fields: Option<String>,
@@ -127,6 +131,7 @@ pub fn parse() -> Cli {
         && !cli.setup
         && !cli.show_config
         && !cli.refresh_field_cache
+        && !cli.clear_vector_cache
         && cli.show_fields.is_none()
         && !cli.export_field_metadata
     {

--- a/src/config.rs
+++ b/src/config.rs
@@ -812,6 +812,7 @@ mod tests {
             setup: false,
             show_config: false,
             refresh_field_cache: false,
+            clear_vector_cache: false,
             show_fields: None,
             export_field_metadata: false,
         };

--- a/src/googleads.rs
+++ b/src/googleads.rs
@@ -341,13 +341,21 @@ pub async fn gaql_query_with_client(
                         {
                             let v: Vec<u64> = columns
                                 .get(i)
-                                .map(|col| col.iter().map(|x| x.parse::<u64>().unwrap()).collect())
+                                .map(|col| {
+                                    col.iter()
+                                        .map(|x| x.parse::<u64>().unwrap_or(0))
+                                        .collect()
+                                })
                                 .unwrap_or_default();
                             series_vec.push(Series::new(header, v));
                         } else {
                             let v: Vec<f64> = columns
                                 .get(i)
-                                .map(|col| col.iter().map(|x| x.parse::<f64>().unwrap()).collect())
+                                .map(|col| {
+                                    col.iter()
+                                        .map(|x| x.parse::<f64>().unwrap_or(0.0))
+                                        .collect()
+                                })
                                 .unwrap_or_default();
                             series_vec.push(Series::new(header, v));
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use mcc_gaql::args::{self, OutputFormat};
 use mcc_gaql::config::{self, ResolvedConfig};
 use mcc_gaql::field_metadata::FieldMetadataCache;
 use mcc_gaql::googleads;
+use mcc_gaql::lancedb_utils;
 use mcc_gaql::prompt2gaql;
 use mcc_gaql::setup;
 use mcc_gaql::util::{self, QueryEntry};
@@ -43,6 +44,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Handle --show-config flag to display configuration
     if args.show_config {
         config::display_config(args.profile.as_deref())?;
+        return Ok(());
+    }
+
+    // Handle --clear-vector-cache flag to clear LanceDB cache
+    if args.clear_vector_cache {
+        lancedb_utils::clear_cache()?;
         return Ok(());
     }
 

--- a/src/prompt2gaql.rs
+++ b/src/prompt2gaql.rs
@@ -6,7 +6,7 @@ use std::vec;
 use lancedb::DistanceType;
 use rig::{
     agent::Agent,
-    client::{CompletionClient, ProviderClient},
+    client::CompletionClient,
     completion::{Completion, Prompt},
     embeddings::{EmbedError, EmbeddingsBuilder, TextEmbedder, embed::Embed},
     providers::openai::{self, completion::CompletionModel},


### PR DESCRIPTION
## Summary

This PR fixes the embedding dimension mismatch error that occurs when switching embedding models (e.g., from 768-dim to 384-dim BAAI/bge-small-en-v1.5).

### Error Fixed
```
lance error: Invalid user input: query dim(384) doesn't match the column vector vector dim(768)
```

### Changes

1. **Added `--clear-vector-cache` CLI flag** - Allows manual clearing of LanceDB vector cache and hash files

2. **Automatic dimension detection** - Schema version now includes embedding dimension (e.g., `v1-dim384`). When `EMBEDDING_DIM` constant changes, cache is automatically invalidated and rebuilt.

3. **Fixed panic on non-numeric metric values** - Changed `.unwrap()` to `.unwrap_or(0)` when parsing Google Ads API numeric responses to prevent crashes on empty/invalid values.

### Testing
- All 43 library tests pass
- Manual test: `./mcc-gaql --clear-vector-cache` successfully clears cache
- Manual test: Natural language query works after cache rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)