### PR TITLE
Update README with LLM config and natural language query docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,10 +311,16 @@ mcc-gaql --profile myprofile --format json "SELECT ..."  # json, csv, or table
 
 ### Natural Language Queries (Experimental)
 
-Using natural language (requires LLM integration):
+Using natural language (requires LLM integration). See [LLM Configuration](#llm-configuration-for-natural-language-queries) for setup instructions.
 
 ```bash
 mcc-gaql -n "campaign changes from last 14 days with current campaign status and bidding strategy" -o recent_changes.csv
+```
+
+Example using a custom model:
+
+```bash
+MCC_GAQL_LLM_MODEL="hf:MiniMaxAI/MiniMax-M2.1" mcc-gaql --profile themade -n "performance from last week, including impression, clicks, prominence metrics, revenue, conversion, and all video metrics, except for trueview metrics" --format csv
 ```
 
 ## CLI Reference
@@ -341,6 +347,7 @@ OPTIONS:
     -l, --list-child-accounts          List all child accounts under MCC
     -m, --mcc-id <MCC_ID>              MCC (Manager) Customer ID for login-customer-id header
     -n, --natural-language             Use natural language prompt instead of GAQL
+        --clear-vector-cache           Clear the vector cache (LanceDB embeddings) and exit
     -o, --output <OUTPUT>              GAQL output filename
     -p, --profile <PROFILE>            Query using profile from config
     -q, --stored-query <STORED_QUERY>  Load named query from file
@@ -374,6 +381,7 @@ OPTIONS:
 | `--show-fields <resource>` | Show available fields for a resource |
 | `--refresh-field-cache` | Refresh field metadata cache from API |
 | `--export-field-metadata` | Export field metadata summary to stdout |
+| `--clear-vector-cache` | Clear the vector cache (LanceDB embeddings) and exit |
 | `--setup` | Run interactive setup wizard |
 | `--show-config` | Show configuration |
 | `--version` | Show version |
@@ -460,6 +468,46 @@ For example:
 export MCC_GAQL_QUERIES_FILENAME="my_queries.toml"
 export MCC_GAQL_FORMAT="csv"
 export MCC_GAQL_KEEP_GOING="true"
+```
+
+### LLM Configuration for Natural Language Queries
+
+Natural language queries require an LLM provider to convert natural language into GAQL. Configure using the following environment variables:
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `MCC_GAQL_LLM_API_KEY` | API key for LLM provider | Yes |
+| `MCC_GAQL_LLM_BASE_URL` | Base URL for LLM provider | Yes |
+| `MCC_GAQL_LLM_MODEL` | Model name (e.g., `google/gemini-flash-2.0`, `gpt-4o-mini`, `hf:MiniMaxAI/MiniMax-M2.1`) | Yes |
+| `MCC_GAQL_LLM_TEMPERATURE` | Temperature for LLM generation (default: 0.1) | No |
+
+#### Provider Examples
+
+**OpenRouter** (default):
+```bash
+export MCC_GAQL_LLM_API_KEY="your_openrouter_api_key"
+export MCC_GAQL_LLM_BASE_URL="https://openrouter.ai/api/v1"
+export MCC_GAQL_LLM_MODEL="google/gemini-flash-2.0"
+```
+
+**OpenAI**:
+```bash
+export MCC_GAQL_LLM_API_KEY="your_openai_api_key"
+export MCC_GAQL_LLM_BASE_URL="https://api.openai.com/v1"
+export MCC_GAQL_LLM_MODEL="gpt-4o-mini"
+```
+
+**Ollama** (local):
+```bash
+export MCC_GAQL_LLM_BASE_URL="http://localhost:11434/v1"
+export MCC_GAQL_LLM_MODEL="llama3.2"
+```
+
+#### Example Commands
+
+Using a specific model with natural language:
+```bash
+MCC_GAQL_LLM_MODEL="hf:MiniMaxAI/MiniMax-M2.1" mcc-gaql --profile themade -n "performance from last week, including impression, clicks, prominence metrics, revenue, conversion, and all video metrics, except for trueview metrics" --format csv
 ```
 
 ## Stored Queries File

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ mcc-gaql --profile myprofile \
 
 ### Field Metadata Management
 
-The tool maintains a local cache of Google Ads field metadata to support natural language queries and field exploration. Use these commands to manage the field cache:
+The tool maintains a local cache of Google Ads field metadata to support [natural language queries](#natural-language-queries-experimental) and field exploration. This cache provides the LLM with knowledge of valid fields, their types, and resource relationships. Use these commands to manage the field cache:
 
 #### Refresh Field Cache
 
@@ -309,15 +309,53 @@ mcc-gaql --profile myprofile \
 # Format output as JSON or table
 mcc-gaql --profile myprofile --format json "SELECT ..."  # json, csv, or table
 
-### Natural Language Queries (Experimental)
+## Natural Language Queries (Experimental)
 
-Using natural language (requires LLM integration). See [LLM Configuration](#llm-configuration-for-natural-language-queries) for setup instructions.
+### Overview
+
+Instead of writing GAQL directly, describe what you want in plain English and the tool will generate and execute the query for you:
 
 ```bash
 mcc-gaql -n "campaign changes from last 14 days with current campaign status and bidding strategy" -o recent_changes.csv
 ```
 
-Example using a custom model:
+### How It Works
+
+The natural language feature uses a **Retrieval-Augmented Generation (RAG)** approach:
+
+1. **Field Metadata Retrieval**: The tool retrieves relevant Google Ads field definitions from your local field cache (see [Field Metadata Management](#field-metadata-management)). This ensures the LLM knows about valid fields, their types, and which resources they belong to.
+
+2. **Example Retrieval**: If you have a [query cookbook](#stored-queries-file) configured, semantically similar example queries are retrieved to provide additional context for the LLM.
+
+3. **LLM Generation**: The configured LLM combines the field metadata and example queries to generate a GAQL query matching your natural language request.
+
+### Setup Requirements
+
+Natural language queries require an LLM provider to be configured. See [LLM Configuration](#llm-configuration-for-natural-language-queries) for detailed setup instructions.
+
+> **Warning**: This feature is **experimental**. The LLM may generate invalid GAQL queries that will result in errors when executed against the Google Ads API. If you're querying multiple accounts, consider using `--keep-going` to continue processing even if the generated query fails on some accounts. Always review generated queries when possible.
+
+### Basic Usage
+
+```bash
+# Simple natural language query
+mcc-gaql -n "show me all campaigns with status and bidding strategy" -o campaigns.csv
+
+# With specific date range and metrics
+mcc-gaql -n "campaign performance last 30 days including impressions, clicks, and cost" --format csv
+```
+
+### Tips for Better Results
+
+- **Be specific about resources**: Mention the resource type explicitly (campaign, ad_group, keyword_view, etc.)
+- **List desired fields**: Name specific metrics or attributes you want included
+- **Specify date ranges**: Include date ranges explicitly (e.g., "last 30 days", "this month", "during last week")
+- **Include filtering criteria**: Add conditions like "where clicks > 100" or "only active campaigns"
+- **Use field metadata**: Run `--refresh-field-cache` periodically to keep the field metadata current
+
+### Example with Custom Model
+
+Override the default model for a specific query:
 
 ```bash
 MCC_GAQL_LLM_MODEL="hf:MiniMaxAI/MiniMax-M2.1" mcc-gaql --profile themade -n "performance from last week, including impression, clicks, prominence metrics, revenue, conversion, and all video metrics, except for trueview metrics" --format csv
@@ -472,7 +510,7 @@ export MCC_GAQL_KEEP_GOING="true"
 
 ### LLM Configuration for Natural Language Queries
 
-Natural language queries require an LLM provider to convert natural language into GAQL. Configure using the following environment variables:
+[Natural language queries](#natural-language-queries-experimental) require an LLM provider to convert natural language into GAQL. Configure using the following environment variables:
 
 | Variable | Description | Required |
 |----------|-------------|----------|

--- a/specs/configurable-llm-provider.md
+++ b/specs/configurable-llm-provider.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-Replace the hardcoded OpenRouter/Gemini Flash LLM configuration with a configurable provider system that supports OpenAI-compatible APIs, including Nano-gpt.com.
+Replace the hardcoded OpenRouter/Gemini Flash LLM configuration with a configurable provider system that supports OpenAI-compatible APIs.
 
 ---
 
@@ -30,7 +30,7 @@ let agent = openrouter_client
 
 **Problems:**
 - Cannot switch providers without code changes
-- Cannot use Nano-gpt.com or other OpenAI-compatible providers
+- Cannot use other OpenAI-compatible providers
 - Requires `OPENROUTER_API_KEY` even if user prefers different provider
 
 ---
@@ -47,11 +47,11 @@ Rig's OpenAI `ClientBuilder` supports custom base URLs:
 use rig::providers::openai;
 
 let client = openai::ClientBuilder::new(&api_key)
-    .base_url("https://nano-gpt.com/api/v1")
+    .base_url("https://api.openai.com/v1")
     .build();
 
 let agent = client
-    .agent("glm-4-9b")
+    .agent("gpt-4o")
     .preamble(&preamble)
     .temperature(0.1)
     .build();
@@ -63,9 +63,9 @@ let agent = client
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `MCC_GAQL_LLM_API_KEY` | API key for the LLM provider | `your-nano-gpt-key` |
-| `MCC_GAQL_LLM_BASE_URL` | Base URL for OpenAI-compatible API | `https://nano-gpt.com/api/v1` |
-| `MCC_GAQL_LLM_MODEL` | Model name | `glm-4-9b` |
+| `MCC_GAQL_LLM_API_KEY` | API key for the LLM provider | `your-api-key` |
+| `MCC_GAQL_LLM_BASE_URL` | Base URL for OpenAI-compatible API | `https://openrouter.ai/api/v1` |
+| `MCC_GAQL_LLM_MODEL` | Model name | `google/gemini-flash-2.0` |
 | `MCC_GAQL_LLM_TEMPERATURE` | Temperature (optional, default: 0.1) | `0.1` |
 
 **Backward Compatibility:**
@@ -82,7 +82,6 @@ Common providers with their base URLs:
 | Provider | Base URL | Example Models |
 |----------|----------|----------------|
 | OpenRouter | `https://openrouter.ai/api/v1` | `google/gemini-flash-2.0`, `anthropic/claude-3.5-sonnet` |
-| Nano-gpt | `https://nano-gpt.com/api/v1` | `glm-4-9b`, `glm-4-plus` |
 | OpenAI | `https://api.openai.com/v1` | `gpt-4o`, `gpt-4-turbo` |
 | Ollama | `http://localhost:11434/v1` | `llama3.1`, `mistral` |
 
@@ -183,17 +182,7 @@ No changes needed - `rig-core` already includes the OpenAI provider.
 
 ## Usage Examples
 
-### Example 1: Nano-gpt with GLM-4
-
-```bash
-export MCC_GAQL_LLM_API_KEY="your-nano-gpt-key"
-export MCC_GAQL_LLM_BASE_URL="https://nano-gpt.com/api/v1"
-export MCC_GAQL_LLM_MODEL="glm-4-9b"
-
-mcc-gaql -n "show me campaigns with high CTR"
-```
-
-### Example 2: OpenRouter (backward compatible)
+### Example 1: OpenRouter (backward compatible)
 
 ```bash
 # Works exactly as before
@@ -201,7 +190,7 @@ export OPENROUTER_API_KEY="your-openrouter-key"
 mcc-gaql -n "show me campaigns"
 ```
 
-### Example 3: Local Ollama
+### Example 2: Local Ollama
 
 ```bash
 export MCC_GAQL_LLM_BASE_URL="http://localhost:11434/v1"
@@ -211,7 +200,7 @@ export MCC_GAQL_LLM_API_KEY="ollama"  # Ollama ignores this but rig requires it
 mcc-gaql -n "show me campaigns"
 ```
 
-### Example 4: One-time override
+### Example 3: One-time override
 
 ```bash
 # Use Claude via OpenRouter just for this query
@@ -242,16 +231,16 @@ fn test_load_llm_config_defaults() {
 
 #[test]
 fn test_load_llm_config_custom() {
-    std::env::set_var("MCC_GAQL_LLM_API_KEY", "nano-key");
-    std::env::set_var("MCC_GAQL_LLM_BASE_URL", "https://nano-gpt.com/api/v1");
-    std::env::set_var("MCC_GAQL_LLM_MODEL", "glm-4-9b");
+    std::env::set_var("MCC_GAQL_LLM_API_KEY", "custom-key");
+    std::env::set_var("MCC_GAQL_LLM_BASE_URL", "https://api.openai.com/v1");
+    std::env::set_var("MCC_GAQL_LLM_MODEL", "gpt-4o");
     std::env::set_var("MCC_GAQL_LLM_TEMPERATURE", "0.2");
 
     let (api_key, base_url, model, temp) = load_llm_config();
 
-    assert_eq!(api_key, "nano-key");
-    assert_eq!(base_url, "https://nano-gpt.com/api/v1");
-    assert_eq!(model, "glm-4-9b");
+    assert_eq!(api_key, "custom-key");
+    assert_eq!(base_url, "https://api.openai.com/v1");
+    assert_eq!(model, "gpt-4o");
     assert_eq!(temp, 0.2);
 }
 ```
@@ -261,10 +250,10 @@ fn test_load_llm_config_custom() {
 ```rust
 #[tokio::test]
 #[ignore]  // Requires real API key
-async fn test_nano_gpt_integration() {
-    std::env::set_var("MCC_GAQL_LLM_API_KEY", std::env::var("NANO_GPT_API_KEY").unwrap());
-    std::env::set_var("MCC_GAQL_LLM_BASE_URL", "https://nano-gpt.com/api/v1");
-    std::env::set_var("MCC_GAQL_LLM_MODEL", "glm-4-9b");
+async fn test_openai_integration() {
+    std::env::set_var("MCC_GAQL_LLM_API_KEY", std::env::var("OPENAI_API_KEY").unwrap());
+    std::env::set_var("MCC_GAQL_LLM_BASE_URL", "https://api.openai.com/v1");
+    std::env::set_var("MCC_GAQL_LLM_MODEL", "gpt-4o-mini");
 
     let result = convert_to_gaql_enhanced(
         vec![],  // empty cookbook for test
@@ -297,15 +286,15 @@ After implementation, verify with:
 # 1. Backward compatibility (should work unchanged)
 OPENROUTER_API_KEY="..." mcc-gaql -n "show campaigns"
 
-# 2. Nano-gpt integration
+# 2. OpenAI integration
 MCC_GAQL_LLM_API_KEY="..." \
-MCC_GAQL_LLM_BASE_URL="https://nano-gpt.com/api/v1" \
-MCC_GAQL_LLM_MODEL="glm-4-9b" \
+MCC_GAQL_LLM_BASE_URL="https://api.openai.com/v1" \
+MCC_GAQL_LLM_MODEL="gpt-4o-mini" \
 mcc-gaql -n "show campaigns"
 
 # 3. Check logs show correct provider
 RUST_LOG=info mcc-gaql -n "show campaigns"
-# Should log: "Using LLM: glm-4-9b via https://nano-gpt.com/api/v1"
+# Should log: "Using LLM: gpt-4o-mini via https://api.openai.com/v1"
 ```
 
 ---
@@ -322,5 +311,5 @@ RUST_LOG=info mcc-gaql -n "show campaigns"
 ## Future Enhancements
 
 1. **Config file support** - Add `[llm]` section to `~/.config/mcc-gaql/config.toml`
-2. **Provider presets** - `LLM_PROVIDER=nano-gpt` auto-sets base_url
+2. **Provider presets** - `LLM_PROVIDER=openai` auto-sets base_url
 3. **Model aliases** - Short names like `glm4` -> `glm-4-9b`


### PR DESCRIPTION
## Summary

Updates README.md to document new features:

1. **New CLI parameter**: `--clear-vector-cache` for clearing the vector cache (LanceDB embeddings)

2. **New LLM Configuration section**: Documents environment variables for natural language queries:
   - `MCC_GAQL_LLM_API_KEY`
   - `MCC_GAQL_LLM_BASE_URL`
   - `MCC_GAQL_LLM_MODEL`
   - `MCC_GAQL_LLM_TEMPERATURE`
   - Provider examples for OpenRouter, OpenAI, and Ollama

3. **Restructured Natural Language Queries section**:
   - Moved to dedicated top-level section (out of Advanced Use Cases)
   - Explains RAG mechanism: field metadata + query cookbook examples + LLM
   - Added experimental warning about potential invalid GAQL generation
   - Tips for writing better natural language prompts
   - Cross-references between Field Metadata, LLM Config, and NL sections

## Changes

- Added `--clear-vector-cache` to CLI Reference and Common Options table
- Created new "LLM Configuration for Natural Language Queries" subsection
- Removed nano-gpt provider references
- Restructured natural language query documentation with detailed explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)