### PR TITLE
Implement multi-model concurrency for LLM enrichment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,17 @@ llm = ["dep:rig-core", "dep:rig-fastembed", "dep:rig-lancedb", "dep:lancedb", "d
 # instead of using embedded credentials. Useful for builds that should not
 # bundle credentials for security or distribution reasons.
 external_client_secret = []
+
+[profile.dev]
+# 1. Reduces the number of parallel "units" the compiler creates. 
+# Lower number = Lower memory usage during linking.
+codegen-units = 1 
+
+# 2. Optimization level 1 makes the code clean enough that the 
+# linker doesn't have to work as hard to merge symbols.
+opt-level = 1
+
+[profile.dev.package."*"]
+# 3. Keep dependencies fast so your LLM/GAQL logic doesn't 
+# drag down the test execution.
+opt-level = 3

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,16 @@
 use std::env;
+use std::process::Command;
 
 fn main() {
     // Tell cargo to rerun if these environment variables change
     println!("cargo:rerun-if-env-changed=MCC_GAQL_EMBED_CLIENT_SECRET");
     println!("cargo:rerun-if-env-changed=MCC_GAQL_DEV_TOKEN");
+
+    // Get the git hash for version info
+    let git_hash = get_git_hash();
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
 
     // Handle client secret embedding
     if let Ok(client_secret_json) = env::var("MCC_GAQL_EMBED_CLIENT_SECRET") {
@@ -40,5 +47,36 @@ fn main() {
         );
         println!("cargo:warning=To embed dev token: set MCC_GAQL_DEV_TOKEN during build");
         println!("cargo:warning=Example: MCC_GAQL_DEV_TOKEN=\"your-token\" cargo build --release");
+    }
+}
+
+/// Get the short git hash, with optional -dirty suffix
+fn get_git_hash() -> String {
+    // Get the git hash
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output();
+
+    let git_hash = match output {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        }
+        _ => "unknown".to_string(),
+    };
+
+    // Check for uncommitted changes
+    let dirty_output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output();
+
+    let is_dirty = match dirty_output {
+        Ok(output) => !output.stdout.is_empty(),
+        _ => false,
+    };
+
+    if is_dirty {
+        format!("{}-dirty", git_hash)
+    } else {
+        git_hash
     }
 }

--- a/specs/multi-model-concurrency.md
+++ b/specs/multi-model-concurrency.md
@@ -1,0 +1,545 @@
+# Multi-Model LLM Concurrency
+
+## Overview
+
+Refactor the LLM handling to support multiple model names with concurrency of 1 per model. This allows increased throughput for high-volume LLM operations (like metadata enrichment) while respecting API provider rate limits.
+
+## Problem Statement
+
+The LLM API provider only supports concurrency of 1 per model. Currently, the codebase:
+- Configures a single model via `MCC_GAQL_LLM_MODEL` environment variable
+- Uses `buffer_unordered(3)` in `metadata_enricher.rs`, potentially hitting rate limits
+
+## Requirements
+
+1. Support multiple LLM models via comma-separated environment variable
+2. First model in the list is the "preferred" model for single requests
+3. `prompt2gaql` always uses the preferred model (single request, no change in behavior)
+4. `metadata_enricher` distributes requests across all models with least-busy-first strategy
+5. Maximum concurrency per model = 1 (enforced via semaphores)
+
+## Design
+
+### Configuration
+
+**Environment variable**: `MCC_GAQL_LLM_MODEL`
+
+```bash
+# Single model (backward compatible)
+export MCC_GAQL_LLM_MODEL="google/gemini-flash-2.0"
+
+# Multiple models (new)
+export MCC_GAQL_LLM_MODEL="google/gemini-flash-2.0,openai/gpt-4o-mini,anthropic/claude-3-haiku"
+```
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         LlmConfig                                │
+│  - api_key, base_url, temperature                               │
+│  - models: Vec<String>  (was: model: String)                    │
+│  - preferred_model() -> &str                                    │
+│  - all_models() -> &[String]                                    │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                         ModelPool                                │
+│  - config: Arc<LlmConfig>                                       │
+│  - semaphores: Vec<Arc<Semaphore>>  (1 permit each)            │
+│                                                                  │
+│  + acquire() -> ModelLease       // least-busy-first           │
+│  + acquire_preferred() -> ModelLease  // always model[0]       │
+│  + model_count() -> usize                                       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                         ModelLease                               │
+│  - model_index: usize                                           │
+│  - model_name: String                                           │
+│  - config: Arc<LlmConfig>                                       │
+│  - _permit: OwnedSemaphorePermit  (releases on drop)           │
+│                                                                  │
+│  + create_agent(system_prompt) -> Agent<CompletionModel>        │
+│  + model_name() -> &str                                         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Component Interactions
+
+```
+┌──────────────────┐     ┌──────────────────┐
+│   prompt2gaql    │     │ metadata_enricher │
+│                  │     │                   │
+│ Uses preferred   │     │ Uses all models   │
+│ model only       │     │ via ModelPool     │
+└────────┬─────────┘     └────────┬──────────┘
+         │                        │
+         │  acquire_preferred()   │  acquire() (least-busy)
+         │                        │
+         ▼                        ▼
+    ┌─────────────────────────────────────┐
+    │             ModelPool               │
+    │                                     │
+    │  ┌─────────┐ ┌─────────┐ ┌────────┐│
+    │  │Model[0] │ │Model[1] │ │Model[2]││
+    │  │Sem(1)   │ │Sem(1)   │ │Sem(1)  ││
+    │  └─────────┘ └─────────┘ └────────┘│
+    └─────────────────────────────────────┘
+```
+
+## Implementation Phases
+
+### Phase 1: Extend `LlmConfig` to Support Multiple Models
+
+**File**: `src/prompt2gaql.rs`
+
+**Changes**:
+
+1. Change `model: String` to `models: Vec<String>` in `LlmConfig` struct
+2. Update `from_env()` to parse comma-separated model names:
+
+```rust
+let models: Vec<String> = env::var("MCC_GAQL_LLM_MODEL")
+    .expect("MCC_GAQL_LLM_MODEL must be set")
+    .split(',')
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+    .collect();
+
+if models.is_empty() {
+    panic!("MCC_GAQL_LLM_MODEL must contain at least one model");
+}
+```
+
+3. Add helper methods:
+
+```rust
+impl LlmConfig {
+    /// Returns the first (preferred) model
+    pub fn preferred_model(&self) -> &str {
+        &self.models[0]
+    }
+
+    /// Returns all configured models
+    pub fn all_models(&self) -> &[String] {
+        &self.models
+    }
+
+    /// Returns the number of configured models
+    pub fn model_count(&self) -> usize {
+        self.models.len()
+    }
+}
+```
+
+4. Update existing methods that use `self.model` to use `self.preferred_model()`:
+   - `create_agent()`
+   - Any other direct `self.model` references
+
+### Phase 2: Create `ModelPool` Abstraction
+
+**New file**: `src/model_pool.rs`
+
+```rust
+use std::sync::Arc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use rig::agent::Agent;
+use rig::providers::openai::CompletionModel;
+
+use crate::prompt2gaql::LlmConfig;
+
+/// Pool of LLM models with per-model concurrency control.
+///
+/// Each model has a semaphore with 1 permit, ensuring only one
+/// request per model at any time.
+pub struct ModelPool {
+    config: Arc<LlmConfig>,
+    semaphores: Vec<Arc<Semaphore>>,
+}
+
+impl ModelPool {
+    /// Create a new model pool from LLM configuration.
+    pub fn new(config: Arc<LlmConfig>) -> Self {
+        let semaphores = config
+            .all_models()
+            .iter()
+            .map(|_| Arc::new(Semaphore::new(1)))
+            .collect();
+
+        Self { config, semaphores }
+    }
+
+    /// Returns the number of models in the pool.
+    pub fn model_count(&self) -> usize {
+        self.semaphores.len()
+    }
+
+    /// Acquire any available model using least-busy-first strategy.
+    ///
+    /// Tries models in order of preference (index 0 first).
+    /// If all models are busy, waits for the first one to become available.
+    pub async fn acquire(&self) -> ModelLease {
+        // First, try to acquire without waiting (prefer earlier models)
+        for (idx, sem) in self.semaphores.iter().enumerate() {
+            if let Ok(permit) = sem.clone().try_acquire_owned() {
+                log::debug!(
+                    "Acquired model {} (index {}) immediately",
+                    self.config.all_models()[idx],
+                    idx
+                );
+                return ModelLease {
+                    model_index: idx,
+                    model_name: self.config.all_models()[idx].clone(),
+                    config: Arc::clone(&self.config),
+                    _permit: permit,
+                };
+            }
+        }
+
+        // All busy - wait for any model to become available
+        log::debug!("All models busy, waiting for availability...");
+
+        // Create futures for all semaphores
+        let futures: Vec<_> = self.semaphores
+            .iter()
+            .enumerate()
+            .map(|(idx, sem)| {
+                let sem = Arc::clone(sem);
+                async move {
+                    let permit = sem.acquire_owned().await.unwrap();
+                    (idx, permit)
+                }
+            })
+            .collect();
+
+        // Race all futures, take the first one that completes
+        let (idx, permit) = futures::future::select_all(futures)
+            .await
+            .0;
+
+        log::debug!(
+            "Acquired model {} (index {}) after waiting",
+            self.config.all_models()[idx],
+            idx
+        );
+
+        ModelLease {
+            model_index: idx,
+            model_name: self.config.all_models()[idx].clone(),
+            config: Arc::clone(&self.config),
+            _permit: permit,
+        }
+    }
+
+    /// Acquire the preferred (first) model specifically.
+    ///
+    /// Use this for operations that should always use the primary model.
+    pub async fn acquire_preferred(&self) -> ModelLease {
+        let permit = self.semaphores[0].clone().acquire_owned().await.unwrap();
+
+        ModelLease {
+            model_index: 0,
+            model_name: self.config.all_models()[0].clone(),
+            config: Arc::clone(&self.config),
+            _permit: permit,
+        }
+    }
+}
+
+/// A lease on a specific model. Releases the model when dropped.
+pub struct ModelLease {
+    model_index: usize,
+    model_name: String,
+    config: Arc<LlmConfig>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl ModelLease {
+    /// Returns the model name for this lease.
+    pub fn model_name(&self) -> &str {
+        &self.model_name
+    }
+
+    /// Returns the model index (0 = preferred).
+    pub fn model_index(&self) -> usize {
+        self.model_index
+    }
+
+    /// Create an LLM agent for this model with the given system prompt.
+    pub fn create_agent(&self, system_prompt: &str) -> Agent<CompletionModel> {
+        self.config.create_agent_for_model(&self.model_name, system_prompt)
+    }
+}
+
+impl Drop for ModelLease {
+    fn drop(&mut self) {
+        log::debug!("Released model {} (index {})", self.model_name, self.model_index);
+    }
+}
+```
+
+**Additional method needed in `LlmConfig`**:
+
+```rust
+impl LlmConfig {
+    /// Create an agent for a specific model name.
+    pub fn create_agent_for_model(
+        &self,
+        model: &str,
+        system_prompt: &str,
+    ) -> Agent<CompletionModel> {
+        let client = self.create_llm_client();
+        client
+            .agent(model)
+            .preamble(system_prompt)
+            .temperature(self.temperature)
+            .build()
+    }
+}
+```
+
+### Phase 3: Update `metadata_enricher.rs`
+
+**File**: `src/metadata_enricher.rs`
+
+**Changes**:
+
+1. Update `MetadataEnricher` struct:
+
+```rust
+// Before
+pub struct MetadataEnricher {
+    llm_config: LlmConfig,
+    batch_size: usize,
+    concurrency: usize,  // Remove this
+}
+
+// After
+pub struct MetadataEnricher {
+    model_pool: Arc<ModelPool>,
+    batch_size: usize,
+    // concurrency derived from model_pool.model_count()
+}
+```
+
+2. Update constructor:
+
+```rust
+impl MetadataEnricher {
+    pub fn new(model_pool: Arc<ModelPool>) -> Self {
+        Self {
+            model_pool,
+            batch_size: 15,
+        }
+    }
+
+    // Or with builder pattern if preferred
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+}
+```
+
+3. Update `enrich()` method to use `ModelPool`:
+
+```rust
+pub async fn enrich(&self, ...) -> Result<...> {
+    // ... batch preparation code unchanged ...
+
+    let model_pool = Arc::clone(&self.model_pool);
+    let scraped = Arc::new(scraped_docs);
+
+    let results: Vec<_> = stream::iter(all_batches.into_iter().enumerate())
+        .map(|(idx, (resource, batch_fields))| {
+            let pool = Arc::clone(&model_pool);
+            let scraped = Arc::clone(&scraped);
+
+            async move {
+                // Acquire a model from the pool (waits if all busy)
+                let lease = pool.acquire().await;
+
+                log::info!(
+                    "Batch {}: enriching {} fields from {} using model {}",
+                    idx,
+                    batch_fields.len(),
+                    resource,
+                    lease.model_name()
+                );
+
+                let result = Self::enrich_batch_with_lease(
+                    &lease,
+                    &resource,
+                    &batch_fields,
+                    &scraped,
+                ).await;
+
+                // lease dropped here, model released
+                result
+            }
+        })
+        .buffer_unordered(self.model_pool.model_count())
+        .collect()
+        .await;
+
+    // ... rest unchanged ...
+}
+```
+
+4. Update `enrich_batch_static` to accept `ModelLease`:
+
+```rust
+// Before
+async fn enrich_batch_static(
+    llm_config: &LlmConfig,
+    ...
+) -> Result<...>
+
+// After
+async fn enrich_batch_with_lease(
+    lease: &ModelLease,
+    resource: &str,
+    fields: &[String],
+    scraped: &ScrapedDocs,
+) -> Result<BatchEnrichmentResult> {
+    let agent = lease.create_agent(ENRICHMENT_SYSTEM_PROMPT);
+
+    let user_prompt = format!(...);
+
+    let response = agent.prompt(&user_prompt).await?;
+
+    // ... parse response ...
+}
+```
+
+### Phase 4: Update `prompt2gaql.rs` (Minimal Changes)
+
+**File**: `src/prompt2gaql.rs`
+
+**Changes**:
+
+1. Ensure `create_agent()` uses `preferred_model()`:
+
+```rust
+impl LlmConfig {
+    pub fn create_agent(&self, system_prompt: &str) -> Agent<CompletionModel> {
+        self.create_agent_for_model(self.preferred_model(), system_prompt)
+    }
+}
+```
+
+2. No changes needed to `RAGAgent` or `EnhancedRAGAgent` - they continue using `config.create_agent()` which now uses the preferred model.
+
+### Phase 5: Update `main.rs` Integration
+
+**File**: `src/main.rs`
+
+**Changes**:
+
+1. Create `ModelPool` at startup when LLM features are used:
+
+```rust
+#[cfg(feature = "llm")]
+let model_pool = {
+    let llm_config = Arc::new(LlmConfig::from_env());
+    log::info!(
+        "LLM configured with {} model(s): {:?}",
+        llm_config.model_count(),
+        llm_config.all_models()
+    );
+    Arc::new(ModelPool::new(llm_config))
+};
+```
+
+2. Pass `model_pool` to `MetadataEnricher`:
+
+```rust
+// Before
+let enricher = MetadataEnricher::new(LlmConfig::from_env());
+
+// After
+let enricher = MetadataEnricher::new(Arc::clone(&model_pool));
+```
+
+3. For `prompt2gaql`, continue passing `LlmConfig` directly (simpler API for single-use):
+
+```rust
+// No change needed - convert_to_gaql() still takes LlmConfig
+// and always uses the preferred model internally
+```
+
+### Phase 6: Update Module Exports
+
+**File**: `src/lib.rs`
+
+```rust
+#[cfg(feature = "llm")]
+pub mod model_pool;
+
+#[cfg(feature = "llm")]
+pub use model_pool::{ModelPool, ModelLease};
+```
+
+## File Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/model_pool.rs` | **Create** | New module with `ModelPool` and `ModelLease` |
+| `src/prompt2gaql.rs` | **Modify** | Multi-model config, `preferred_model()`, `create_agent_for_model()` |
+| `src/metadata_enricher.rs` | **Modify** | Use `ModelPool` for concurrent access |
+| `src/main.rs` | **Modify** | Create `ModelPool`, wire dependencies |
+| `src/lib.rs` | **Modify** | Export new module |
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **`LlmConfig` parsing**:
+   - Single model: `"model-a"` → `["model-a"]`
+   - Multiple models: `"model-a,model-b,model-c"` → `["model-a", "model-b", "model-c"]`
+   - With whitespace: `" model-a , model-b "` → `["model-a", "model-b"]`
+   - Empty string: panic
+   - Empty after split: `",,"` → panic
+
+2. **`ModelPool::acquire()`**:
+   - With 3 models and 3 concurrent tasks, each gets a different model
+   - With 3 models and 5 concurrent tasks, 2 tasks wait
+
+3. **`ModelPool::acquire_preferred()`**:
+   - Always returns model index 0
+   - Multiple calls wait for each other
+
+### Integration Tests
+
+1. Mock HTTP server that tracks request concurrency per model
+2. Run `MetadataEnricher` with 3 models
+3. Verify max 1 concurrent request per model
+
+### Manual Testing
+
+```bash
+# Set multiple models
+export MCC_GAQL_LLM_MODEL="google/gemini-flash-2.0,openai/gpt-4o-mini"
+export MCC_GAQL_LOG_LEVEL="debug"
+
+# Run metadata enrichment
+cargo run -- --enrich-metadata --profile test
+
+# Observe logs showing model distribution
+```
+
+## Backward Compatibility
+
+- Single model configuration continues to work unchanged
+- `prompt2gaql` behavior unchanged (always uses first model)
+- `metadata_enricher` concurrency now equals model count instead of hardcoded 3
+
+## Future Considerations
+
+1. **Model-specific parameters**: Different temperatures or system prompts per model
+2. **Retry with different model**: On failure, try next available model
+3. **Model health tracking**: Track success rates, prefer healthy models
+4. **Config file support**: Add `[llm]` section to `config.toml` for persistent multi-model config

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,6 +2,12 @@ use anyhow::Result;
 use clap::Parser;
 use std::io::{self, Read};
 use std::str::FromStr;
+use std::sync::LazyLock;
+
+/// Version string including git hash (computed lazily at first use)
+static VERSION: LazyLock<String> = LazyLock::new(|| {
+    format!("{} ({})", env!("CARGO_PKG_VERSION"), env!("GIT_HASH"))
+});
 
 /// Output format for query results
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,7 +38,7 @@ impl FromStr for OutputFormat {
 /// Supports profile-based configuration and ENV VAR override.
 ///
 #[derive(Parser, Debug)]
-#[clap(author, version, about)]
+#[clap(author, about, version = VERSION.as_str())]
 pub struct Cli {
     /// Google Ads GAQL query to run
     pub gaql_query: Option<String>,

--- a/src/field_metadata.rs
+++ b/src/field_metadata.rs
@@ -83,9 +83,21 @@ impl FieldMetadata {
 
         // Field name + structural tags
         let flags: Vec<&str> = [
-            if self.selectable { Some("selectable") } else { None },
-            if self.filterable { Some("filterable") } else { None },
-            if self.sortable { Some("sortable") } else { None },
+            if self.selectable {
+                Some("selectable")
+            } else {
+                None
+            },
+            if self.filterable {
+                Some("filterable")
+            } else {
+                None
+            },
+            if self.sortable {
+                Some("sortable")
+            } else {
+                None
+            },
         ]
         .into_iter()
         .flatten()
@@ -121,10 +133,11 @@ impl FieldMetadata {
         // Resource context
         if !self.attribute_resources.is_empty() {
             parts.push(format!("Resource: {}", self.attribute_resources.join(", ")));
-        } else if let Some(r) = self.get_resource() {
-            if r != "metrics" && r != "segments" {
-                parts.push(format!("Resource: {}", r));
-            }
+        } else if let Some(r) = self.get_resource()
+            && r != "metrics"
+            && r != "segments"
+        {
+            parts.push(format!("Resource: {}", r));
         }
 
         parts.join(". ")
@@ -341,10 +354,8 @@ impl FieldMetadataCache {
         let mut resource_metadata = HashMap::new();
 
         for (resource_name, field_names) in resources {
-            let resource_fields: Vec<&FieldMetadata> = field_names
-                .iter()
-                .filter_map(|n| fields.get(n))
-                .collect();
+            let resource_fields: Vec<&FieldMetadata> =
+                field_names.iter().filter_map(|n| fields.get(n)).collect();
 
             // Collect key attributes (selectable + filterable)
             let mut key_attributes: Vec<String> = resource_fields
@@ -518,7 +529,10 @@ impl FieldMetadataCache {
 
     /// Count enriched fields (those with a description set)
     pub fn enriched_field_count(&self) -> usize {
-        self.fields.values().filter(|f| f.description.is_some()).count()
+        self.fields
+            .values()
+            .filter(|f| f.description.is_some())
+            .count()
     }
 
     /// Validate if a set of fields can be selected together
@@ -657,7 +671,10 @@ impl FieldMetadataCache {
                     .as_deref()
                     .map(|d| format!(" — {}", d))
                     .unwrap_or_default();
-                output.push_str(&format!("- {}: {}{}\n", field.name, field.data_type, desc_suffix));
+                output.push_str(&format!(
+                    "- {}: {}{}\n",
+                    field.name, field.data_type, desc_suffix
+                ));
             }
         }
 
@@ -681,17 +698,20 @@ impl FieldMetadataCache {
         for resource in &resources {
             let field_count = self.get_resource_fields(resource).len();
 
-            let (selectable_with, key_attrs, key_metrics, desc) =
-                if let Some(rm) = self.resource_metadata.as_ref().and_then(|m| m.get(resource)) {
-                    (
-                        rm.selectable_with.clone(),
-                        rm.key_attributes.clone(),
-                        rm.key_metrics.clone(),
-                        rm.description.clone(),
-                    )
-                } else {
-                    (vec![], vec![], vec![], None)
-                };
+            let (selectable_with, key_attrs, key_metrics, desc) = if let Some(rm) = self
+                .resource_metadata
+                .as_ref()
+                .and_then(|m| m.get(resource))
+            {
+                (
+                    rm.selectable_with.clone(),
+                    rm.key_attributes.clone(),
+                    rm.key_metrics.clone(),
+                    rm.description.clone(),
+                )
+            } else {
+                (vec![], vec![], vec![], None)
+            };
 
             output.push_str(&format!("## {}\n", resource));
             output.push_str(&format!("Fields: {}\n", field_count));
@@ -701,7 +721,8 @@ impl FieldMetadataCache {
             }
 
             if !selectable_with.is_empty() {
-                let displayed: Vec<&str> = selectable_with.iter().take(8).map(String::as_str).collect();
+                let displayed: Vec<&str> =
+                    selectable_with.iter().take(8).map(String::as_str).collect();
                 let suffix = if selectable_with.len() > 8 {
                     format!(" (+{})", selectable_with.len() - 8)
                 } else {
@@ -820,7 +841,9 @@ pub fn get_enriched_cache_path() -> Result<PathBuf> {
     let cache_dir =
         dirs::cache_dir().ok_or_else(|| anyhow!("Could not determine cache directory"))?;
 
-    Ok(cache_dir.join("mcc-gaql").join("field_metadata_enriched.json"))
+    Ok(cache_dir
+        .join("mcc-gaql")
+        .join("field_metadata_enriched.json"))
 }
 
 #[cfg(test)]
@@ -885,7 +908,11 @@ mod tests {
             metrics_compatible: true,
             resource_name: None,
             selectable_with: vec![],
-            enum_values: vec!["ENABLED".to_string(), "PAUSED".to_string(), "REMOVED".to_string()],
+            enum_values: vec![
+                "ENABLED".to_string(),
+                "PAUSED".to_string(),
+                "REMOVED".to_string(),
+            ],
             attribute_resources: vec!["campaign".to_string()],
             description: Some("Current serving status of the campaign.".to_string()),
             usage_notes: Some("Filter with = to focus on active campaigns.".to_string()),

--- a/src/googleads.rs
+++ b/src/googleads.rs
@@ -296,11 +296,7 @@ async fn verify_and_confirm_auth(
     token_cache_path: &std::path::Path,
 ) -> Result<()> {
     // Get user info from the token
-    let user_email = access
-        .user_email
-        .as_ref()
-        .map(|e| e.as_str())
-        .unwrap_or("(unknown)");
+    let user_email = access.user_email.as_deref().unwrap_or("(unknown)");
 
     println!("\nAuthenticated as: {}", user_email);
     println!("Token will be saved to: {}", token_cache_path.display());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,11 @@ pub mod lancedb_utils;
 pub mod metadata_enricher;
 pub mod metadata_scraper;
 #[cfg(feature = "llm")]
+pub mod model_pool;
+#[cfg(feature = "llm")]
 pub mod prompt2gaql;
 pub mod setup;
 pub mod util;
+
+#[cfg(feature = "llm")]
+pub use model_pool::{ModelLease, ModelPool};

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,13 @@ use mcc_gaql::metadata_enricher;
 #[cfg(feature = "llm")]
 use mcc_gaql::metadata_scraper;
 #[cfg(feature = "llm")]
+use mcc_gaql::model_pool::ModelPool;
+#[cfg(feature = "llm")]
 use mcc_gaql::prompt2gaql;
 use mcc_gaql::setup;
+use mcc_gaql::util;
 #[cfg(feature = "llm")]
 use mcc_gaql::util::QueryEntry;
-use mcc_gaql::util;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -66,7 +68,9 @@ async fn main() -> Result<()> {
     }
     #[cfg(not(feature = "llm"))]
     if args.clear_vector_cache {
-        return Err(anyhow::anyhow!("LLM features not enabled. Rebuild with --features llm"));
+        return Err(anyhow::anyhow!(
+            "LLM features not enabled. Rebuild with --features llm"
+        ));
     }
 
     // Validate argument combinations
@@ -90,27 +94,26 @@ async fn main() -> Result<()> {
         log::debug!("Handle Field Metadata command. Resolved configuration: {resolved_config:?}");
 
         // Obtain API access for field metadata operations
-        let api_context =
-            if args.refresh_field_cache
-                || args.export_field_metadata
-                || args.show_fields.is_some()
-                || args.refresh_metadata
-            {
-                resolved_config.validate_for_operation(&args)?;
-                Some(
-                    googleads::get_api_access(&googleads::ApiAccessConfig {
-                        mcc_customer_id: resolved_config.mcc_customer_id.clone(),
-                        token_cache_filename: resolved_config.token_cache_filename.clone(),
-                        user_email: resolved_config.user_email.clone(),
-                        dev_token: resolved_config.dev_token.clone(),
-                        use_remote_auth: resolved_config.remote_auth,
-                    })
-                    .await
-                    .context("Authentication required for field metadata operations")?,
-                )
-            } else {
-                None
-            };
+        let api_context = if args.refresh_field_cache
+            || args.export_field_metadata
+            || args.show_fields.is_some()
+            || args.refresh_metadata
+        {
+            resolved_config.validate_for_operation(&args)?;
+            Some(
+                googleads::get_api_access(&googleads::ApiAccessConfig {
+                    mcc_customer_id: resolved_config.mcc_customer_id.clone(),
+                    token_cache_filename: resolved_config.token_cache_filename.clone(),
+                    user_email: resolved_config.user_email.clone(),
+                    dev_token: resolved_config.dev_token.clone(),
+                    use_remote_auth: resolved_config.remote_auth,
+                })
+                .await
+                .context("Authentication required for field metadata operations")?,
+            )
+        } else {
+            None
+        };
 
         let cache_path = std::path::PathBuf::from(&resolved_config.field_metadata_cache);
 
@@ -205,10 +208,19 @@ async fn main() -> Result<()> {
                     "Either MCC_GAQL_LLM_API_KEY or OPENROUTER_API_KEY must be set for --refresh-metadata"
                 ));
             }
-            let llm_config = prompt2gaql::LlmConfig::from_env();
+            let llm_config = std::sync::Arc::new(prompt2gaql::LlmConfig::from_env());
+            log::info!(
+                "LLM configured with {} model(s): {:?}",
+                llm_config.model_count(),
+                llm_config.all_models()
+            );
+            let model_pool =
+                std::sync::Arc::new(ModelPool::new(std::sync::Arc::clone(&llm_config)));
 
             // Stage 0: Fetch fresh structural metadata from Fields Service API
-            println!("Stage 0/2: Fetching structural metadata from Google Ads Fields Service API...");
+            println!(
+                "Stage 0/2: Fetching structural metadata from Google Ads Fields Service API..."
+            );
             let mut cache =
                 FieldMetadataCache::fetch_from_api(api_context.as_ref().unwrap()).await?;
             println!(
@@ -228,10 +240,10 @@ async fn main() -> Result<()> {
             // Stages 1 and 2: Scrape + LLM enrich
             metadata_enricher::run_enrichment_pipeline(
                 &mut cache,
-                &llm_config,
+                model_pool,
                 &scrape_cache_path,
-                30,   // scrape TTL: 30 days
-                500,  // rate limit: 500ms between requests
+                30,  // scrape TTL: 30 days
+                500, // rate limit: 500ms between requests
             )
             .await?;
 
@@ -260,7 +272,9 @@ async fn main() -> Result<()> {
         }
         #[cfg(not(feature = "llm"))]
         if args.refresh_metadata {
-            return Err(anyhow::anyhow!("LLM features not enabled. Rebuild with --features llm"));
+            return Err(anyhow::anyhow!(
+                "LLM features not enabled. Rebuild with --features llm"
+            ));
         }
     }
 
@@ -396,7 +410,9 @@ async fn main() -> Result<()> {
     }
     #[cfg(not(feature = "llm"))]
     if args.natural_language {
-        return Err(anyhow::anyhow!("LLM features not enabled. Rebuild with --features llm"));
+        return Err(anyhow::anyhow!(
+            "LLM features not enabled. Rebuild with --features llm"
+        ));
     }
 
     // for non-FieldService queries, reduce network traffic by excluding resource_name by default

--- a/src/metadata_enricher.rs
+++ b/src/metadata_enricher.rs
@@ -20,54 +20,53 @@ use std::sync::Arc;
 
 use crate::field_metadata::{FieldMetadata, FieldMetadataCache, ResourceMetadata};
 use crate::metadata_scraper::ScrapedDocs;
-use crate::prompt2gaql::LlmConfig;
+use crate::model_pool::{ModelLease, ModelPool};
 
 /// LLM-based enricher for Google Ads field metadata
 pub struct MetadataEnricher {
-    llm_config: LlmConfig,
+    model_pool: Arc<ModelPool>,
     /// Maximum fields per LLM batch (controls token usage)
     batch_size: usize,
-    /// Maximum concurrent LLM API calls
-    concurrency: usize,
 }
 
 impl MetadataEnricher {
-    pub fn new(llm_config: LlmConfig) -> Self {
+    /// Create a new enricher backed by the given model pool.
+    pub fn new(model_pool: Arc<ModelPool>) -> Self {
         Self {
-            llm_config,
+            model_pool,
             batch_size: 15,
-            concurrency: 3, // Default: 3 concurrent LLM calls
         }
     }
 
+    /// Override the number of fields sent per LLM batch (default: 15).
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self
     }
 
-    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
-        self.concurrency = concurrency.max(1); // At least 1
-        self
-    }
-
     /// Enrich all fields in the cache with LLM-generated descriptions.
     /// Also enriches resource-level metadata.
-    /// Uses concurrent processing for improved performance.
+    /// Uses concurrent processing across all models in the pool.
     /// Modifies the cache in place.
-    pub async fn enrich(&self, cache: &mut FieldMetadataCache, scraped: &ScrapedDocs) -> Result<()> {
+    pub async fn enrich(
+        &self,
+        cache: &mut FieldMetadataCache,
+        scraped: &ScrapedDocs,
+    ) -> Result<()> {
         let resources = cache.get_resources();
         let total_resources = resources.len();
+        let concurrency = self.model_pool.model_count();
 
         log::info!(
             "Starting LLM enrichment for {} resources ({} fields total, concurrency: {})",
             total_resources,
             cache.fields.len(),
-            self.concurrency
+            concurrency
         );
 
         // Wrap scraped docs in Arc for sharing across concurrent tasks
         let scraped = Arc::new(scraped.clone());
-        let llm_config = Arc::new(self.llm_config.clone());
+        let model_pool = Arc::clone(&self.model_pool);
 
         // Collect all batches across all resources for parallel processing
         let mut all_batches: Vec<(String, Vec<FieldMetadata>)> = Vec::new();
@@ -96,32 +95,37 @@ impl MetadataEnricher {
         }
 
         let total_batches = all_batches.len();
-        log::info!("Processing {} batches with concurrency {}", total_batches, self.concurrency);
+        log::info!(
+            "Processing {} batches with concurrency {}",
+            total_batches,
+            concurrency
+        );
 
-        // Process batches concurrently using buffer_unordered
-        let batch_size = self.batch_size;
+        // Process batches concurrently using buffer_unordered(model_count).
+        // Each task acquires a model lease from the pool so that at most one
+        // request is in-flight per model at any time.
         let results: Vec<_> = stream::iter(all_batches.into_iter().enumerate())
             .map(|(idx, (resource, batch_fields))| {
+                let pool = Arc::clone(&model_pool);
                 let scraped = Arc::clone(&scraped);
-                let llm_config = Arc::clone(&llm_config);
                 async move {
+                    // Acquire a model lease (waits if all models are busy)
+                    let lease = pool.acquire().await;
+
                     log::info!(
-                        "[{}/{}] Enriching batch for resource: {} ({} fields)",
+                        "[{}/{}] Enriching batch for resource: {} ({} fields) using model '{}'",
                         idx + 1,
                         total_batches,
                         resource,
-                        batch_fields.len()
+                        batch_fields.len(),
+                        lease.model_name()
                     );
 
-                    let result = Self::enrich_batch_static(
-                        &llm_config,
-                        &resource,
-                        &batch_fields,
-                        &scraped,
-                        batch_size,
-                    )
-                    .await;
+                    let result =
+                        Self::enrich_batch_with_lease(&lease, &resource, &batch_fields, &scraped)
+                            .await;
 
+                    // lease dropped here, model slot released
                     match &result {
                         Ok(descriptions) => {
                             log::info!(
@@ -144,30 +148,31 @@ impl MetadataEnricher {
                     result
                 }
             })
-            .buffer_unordered(self.concurrency)
+            .buffer_unordered(concurrency)
             .collect()
             .await;
 
         // Apply all results to the cache
-        for result in results {
-            if let Ok(descriptions) = result {
-                for (field_name, (description, usage_notes)) in descriptions {
-                    if let Some(field) = cache.fields.get_mut(&field_name) {
-                        if !description.is_empty() {
-                            field.description = Some(description);
-                        }
-                        if let Some(notes) = usage_notes {
-                            if !notes.is_empty() {
-                                field.usage_notes = Some(notes);
-                            }
-                        }
+        for descriptions in results.into_iter().flatten() {
+            for (field_name, (description, usage_notes)) in descriptions {
+                if let Some(field) = cache.fields.get_mut(&field_name) {
+                    if !description.is_empty() {
+                        field.description = Some(description);
+                    }
+                    if let Some(notes) = usage_notes
+                        && !notes.is_empty()
+                    {
+                        field.usage_notes = Some(notes);
                     }
                 }
             }
         }
 
         // Enrich resource-level metadata (sequential, since there are fewer resources)
-        log::info!("Enriching resource-level metadata for {} resources", resources.len());
+        log::info!(
+            "Enriching resource-level metadata for {} resources",
+            resources.len()
+        );
         for resource in &resources {
             if let Some(rm) = cache
                 .resource_metadata
@@ -181,7 +186,11 @@ impl MetadataEnricher {
                         }
                     }
                     Err(e) => {
-                        log::warn!("  Resource description generation failed for '{}': {}", resource, e);
+                        log::warn!(
+                            "  Resource description generation failed for '{}': {}",
+                            resource,
+                            e
+                        );
                     }
                 }
             }
@@ -197,13 +206,15 @@ impl MetadataEnricher {
         Ok(())
     }
 
-    /// Static version of enrich_batch for use in concurrent contexts
-    async fn enrich_batch_static(
-        llm_config: &LlmConfig,
+    /// Enrich a batch of fields using the model referenced by `lease`.
+    ///
+    /// The caller is responsible for acquiring the lease from a [`ModelPool`]
+    /// and dropping it when this call returns.
+    async fn enrich_batch_with_lease(
+        lease: &ModelLease,
         resource: &str,
         fields: &[FieldMetadata],
         scraped: &ScrapedDocs,
-        _batch_size: usize,
     ) -> Result<HashMap<String, (String, Option<String>)>> {
         let system_prompt = "\
 You are a Google Ads API documentation expert. Your task is to write concise, \
@@ -230,7 +241,7 @@ Use in SELECT to label rows in reports.\",\n\
 
         let user_prompt = Self::build_batch_prompt_static(resource, fields, scraped);
 
-        let agent = llm_config
+        let agent = lease
             .create_agent(system_prompt)
             .context("Failed to create LLM agent for enrichment")?;
 
@@ -261,9 +272,21 @@ Use in SELECT to label rows in reports.\",\n\
             ));
 
             let flags: Vec<&str> = [
-                if field.selectable { Some("selectable") } else { None },
-                if field.filterable { Some("filterable") } else { None },
-                if field.sortable { Some("sortable") } else { None },
+                if field.selectable {
+                    Some("selectable")
+                } else {
+                    None
+                },
+                if field.filterable {
+                    Some("filterable")
+                } else {
+                    None
+                },
+                if field.sortable {
+                    Some("sortable")
+                } else {
+                    None
+                },
             ]
             .into_iter()
             .flatten()
@@ -273,22 +296,28 @@ Use in SELECT to label rows in reports.\",\n\
             }
 
             if !field.enum_values.is_empty() {
-                let values: Vec<&str> = field.enum_values.iter().take(20).map(String::as_str).collect();
+                let values: Vec<&str> = field
+                    .enum_values
+                    .iter()
+                    .take(20)
+                    .map(String::as_str)
+                    .collect();
                 prompt.push_str(&format!("  Enum values: {}\n", values.join(", ")));
             }
 
             if let Some(scraped_desc) = scraped.get_description(&field.name) {
                 prompt.push_str(&format!("  Documentation: {}\n", scraped_desc));
             }
-            if let Some(scraped_enums) = scraped.get_enum_values(&field.name) {
-                if !field.enum_values.is_empty() {
-                    let scraped_str: Vec<&str> = scraped_enums.iter().take(10).map(String::as_str).collect();
-                    if !scraped_str.is_empty() {
-                        prompt.push_str(&format!(
-                            "  Additional enum context: {}\n",
-                            scraped_str.join(", ")
-                        ));
-                    }
+            if let Some(scraped_enums) = scraped.get_enum_values(&field.name)
+                && !field.enum_values.is_empty()
+            {
+                let scraped_str: Vec<&str> =
+                    scraped_enums.iter().take(10).map(String::as_str).collect();
+                if !scraped_str.is_empty() {
+                    prompt.push_str(&format!(
+                        "  Additional enum context: {}\n",
+                        scraped_str.join(", ")
+                    ));
                 }
             }
 
@@ -332,7 +361,10 @@ Use in SELECT to label rows in reports.\",\n\
                     result.insert(field_name.clone(), (s.clone(), None));
                 }
                 _ => {
-                    log::debug!("Unexpected JSON value type for field '{}', skipping", field_name);
+                    log::debug!(
+                        "Unexpected JSON value type for field '{}', skipping",
+                        field_name
+                    );
                 }
             }
         }
@@ -361,13 +393,23 @@ used to query. Return ONLY the sentence, no formatting.";
         if !rm.key_attributes.is_empty() {
             user_prompt.push_str(&format!(
                 "Key attributes: {}\n",
-                rm.key_attributes.iter().take(5).cloned().collect::<Vec<_>>().join(", ")
+                rm.key_attributes
+                    .iter()
+                    .take(5)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
         }
         if !rm.key_metrics.is_empty() {
             user_prompt.push_str(&format!(
                 "Key metrics: {}\n",
-                rm.key_metrics.iter().take(5).cloned().collect::<Vec<_>>().join(", ")
+                rm.key_metrics
+                    .iter()
+                    .take(5)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
         }
 
@@ -376,15 +418,14 @@ used to query. Return ONLY the sentence, no formatting.";
             user_prompt.push_str(&format!("Documentation: {}\n", scraped_desc));
         }
 
-        let agent = self
-            .llm_config
+        let lease = self.model_pool.acquire_preferred().await;
+        let agent = lease
             .create_agent(system_prompt)
             .context("Failed to create LLM agent for resource enrichment")?;
 
-        let response = agent
-            .prompt(&user_prompt)
-            .await
-            .map_err(|e| anyhow::anyhow!("LLM prompt failed for resource {}: {}", resource_name, e))?;
+        let response = agent.prompt(&user_prompt).await.map_err(|e| {
+            anyhow::anyhow!("LLM prompt failed for resource {}: {}", resource_name, e)
+        })?;
 
         Ok(response.trim().to_string())
     }
@@ -421,7 +462,7 @@ fn strip_json_fences(s: &str) -> String {
 /// Returns the modified cache (caller is responsible for saving to disk).
 pub async fn run_enrichment_pipeline(
     cache: &mut FieldMetadataCache,
-    llm_config: &LlmConfig,
+    model_pool: Arc<ModelPool>,
     scrape_cache_path: &std::path::Path,
     scrape_ttl_days: i64,
     scrape_delay_ms: u64,
@@ -454,7 +495,7 @@ pub async fn run_enrichment_pipeline(
         "Stage 2/2: Generating LLM descriptions for {} fields...",
         cache.fields.len()
     );
-    let enricher = MetadataEnricher::new(llm_config.clone());
+    let enricher = MetadataEnricher::new(model_pool);
     enricher.enrich(cache, &scraped).await?;
 
     println!(

--- a/src/metadata_scraper.rs
+++ b/src/metadata_scraper.rs
@@ -313,7 +313,11 @@ impl ScrapedDocs {
         fs::write(path, &contents)
             .await
             .context("Failed to write scraped docs cache")?;
-        log::info!("Saved scraped docs cache to {:?} ({} fields)", path, self.docs.len());
+        log::info!(
+            "Saved scraped docs cache to {:?} ({} fields)",
+            path,
+            self.docs.len()
+        );
         Ok(())
     }
 }
@@ -430,8 +434,8 @@ fn extract_enum_values_from_section(heading: &scraper::ElementRef) -> Vec<String
 
 /// Helper to get the default scraped docs cache path
 pub fn get_scraped_docs_cache_path() -> Result<std::path::PathBuf> {
-    let cache_dir = dirs::cache_dir()
-        .ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
+    let cache_dir =
+        dirs::cache_dir().ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
     Ok(cache_dir.join("mcc-gaql").join("scraped_docs.json"))
 }
 

--- a/src/model_pool.rs
+++ b/src/model_pool.rs
@@ -1,0 +1,289 @@
+// Pool of LLM models with per-model concurrency control.
+//
+// Each model gets a semaphore with exactly 1 permit, ensuring that at most one
+// request is in-flight per model at any time (matching provider rate-limit
+// constraints).  Callers acquire a `ModelLease`, use it to create an agent,
+// then simply drop the lease to release the slot.
+
+use std::sync::Arc;
+
+use rig::agent::Agent;
+use rig::providers::openai::completion::CompletionModel;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::prompt2gaql::LlmConfig;
+
+/// Pool of LLM models with per-model concurrency control.
+///
+/// Each model has a semaphore with 1 permit, ensuring only one request per
+/// model is in-flight at any time.  Use [`ModelPool::acquire`] to obtain the
+/// next available model, or [`ModelPool::acquire_preferred`] to wait
+/// specifically for model index 0.
+pub struct ModelPool {
+    config: Arc<LlmConfig>,
+    /// One semaphore per model; semaphore index == model index in `config`.
+    semaphores: Vec<Arc<Semaphore>>,
+}
+
+impl ModelPool {
+    /// Create a new model pool from LLM configuration.
+    ///
+    /// One semaphore (1 permit) is allocated for every model in `config`.
+    pub fn new(config: Arc<LlmConfig>) -> Self {
+        let semaphores = config
+            .all_models()
+            .iter()
+            .map(|_| Arc::new(Semaphore::new(1)))
+            .collect();
+
+        Self { config, semaphores }
+    }
+
+    /// Returns the number of models in the pool.
+    pub fn model_count(&self) -> usize {
+        self.semaphores.len()
+    }
+
+    /// Acquire any available model using a least-busy-first strategy.
+    ///
+    /// Models are tried in order (index 0 first) without blocking.  If all
+    /// models are currently busy the method races all semaphores and returns
+    /// whichever becomes free first.
+    pub async fn acquire(&self) -> ModelLease {
+        // Fast path: try each model in order without waiting.
+        for (idx, sem) in self.semaphores.iter().enumerate() {
+            if let Ok(permit) = sem.clone().try_acquire_owned() {
+                log::debug!(
+                    "Acquired model '{}' (index {}) immediately",
+                    self.config.all_models()[idx],
+                    idx
+                );
+                return ModelLease {
+                    model_index: idx,
+                    model_name: self.config.all_models()[idx].clone(),
+                    config: Arc::clone(&self.config),
+                    _permit: permit,
+                };
+            }
+        }
+
+        // Slow path: all models busy – race all semaphores and take the winner.
+        log::debug!("All models busy, waiting for any model to become available...");
+
+        let futures: Vec<_> = self
+            .semaphores
+            .iter()
+            .enumerate()
+            .map(|(idx, sem)| {
+                let sem = Arc::clone(sem);
+                Box::pin(async move {
+                    let permit = sem
+                        .acquire_owned()
+                        .await
+                        .expect("semaphore closed unexpectedly");
+                    (idx, permit)
+                })
+            })
+            .collect();
+
+        let ((idx, permit), _, _) = futures::future::select_all(futures).await;
+
+        log::debug!(
+            "Acquired model '{}' (index {}) after waiting",
+            self.config.all_models()[idx],
+            idx
+        );
+
+        ModelLease {
+            model_index: idx,
+            model_name: self.config.all_models()[idx].clone(),
+            config: Arc::clone(&self.config),
+            _permit: permit,
+        }
+    }
+
+    /// Acquire the preferred (first) model specifically.
+    ///
+    /// Blocks until model index 0 is available.  Use this for operations that
+    /// should always use the primary model regardless of pool load.
+    pub async fn acquire_preferred(&self) -> ModelLease {
+        let permit = self.semaphores[0]
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("semaphore closed unexpectedly");
+
+        log::debug!(
+            "Acquired preferred model '{}' (index 0)",
+            self.config.all_models()[0]
+        );
+
+        ModelLease {
+            model_index: 0,
+            model_name: self.config.all_models()[0].clone(),
+            config: Arc::clone(&self.config),
+            _permit: permit,
+        }
+    }
+}
+
+/// A lease on a specific model.  The associated semaphore permit is released
+/// when this value is dropped, making the model slot available again.
+pub struct ModelLease {
+    model_index: usize,
+    model_name: String,
+    config: Arc<LlmConfig>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl ModelLease {
+    /// Returns the model name for this lease.
+    pub fn model_name(&self) -> &str {
+        &self.model_name
+    }
+
+    /// Returns the model index (0 == preferred model).
+    pub fn model_index(&self) -> usize {
+        self.model_index
+    }
+
+    /// Create an LLM agent for this model with the given system prompt.
+    pub fn create_agent(
+        &self,
+        system_prompt: &str,
+    ) -> Result<Agent<CompletionModel>, anyhow::Error> {
+        self.config
+            .create_agent_for_model(&self.model_name, system_prompt)
+    }
+}
+
+impl Drop for ModelLease {
+    fn drop(&mut self) {
+        log::debug!(
+            "Released model '{}' (index {})",
+            self.model_name,
+            self.model_index
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::prompt2gaql::LlmConfig;
+
+    /// Build a `ModelPool` with the given model names for testing purposes.
+    fn make_pool(model_names: &[&str]) -> ModelPool {
+        let models: Vec<String> = model_names.iter().map(|s| s.to_string()).collect();
+        let config = Arc::new(LlmConfig::from_models_for_test(models));
+        ModelPool::new(config)
+    }
+
+    #[test]
+    fn test_model_pool_model_count() {
+        let pool = make_pool(&["model-a", "model-b", "model-c"]);
+        assert_eq!(pool.model_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_acquire_returns_available_model() {
+        let pool = make_pool(&["model-a", "model-b", "model-c"]);
+        let lease = pool.acquire().await;
+        assert_eq!(lease.model_name(), "model-a");
+        assert_eq!(lease.model_index(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_acquire_preferred_always_index_zero() {
+        let pool = Arc::new(make_pool(&["model-a", "model-b"]));
+        let lease = pool.acquire_preferred().await;
+        assert_eq!(lease.model_index(), 0);
+        assert_eq!(lease.model_name(), "model-a");
+    }
+
+    #[tokio::test]
+    async fn test_acquire_uses_next_available_when_preferred_busy() {
+        let pool = make_pool(&["model-a", "model-b", "model-c"]);
+        // Hold model-a
+        let _lease_a = pool.acquire().await;
+        assert_eq!(_lease_a.model_index(), 0);
+
+        // Next acquire should go to model-b (index 1)
+        let lease_b = pool.acquire().await;
+        assert_eq!(lease_b.model_index(), 1);
+        assert_eq!(lease_b.model_name(), "model-b");
+    }
+
+    #[tokio::test]
+    async fn test_acquire_three_concurrent_different_models() {
+        let pool = Arc::new(make_pool(&["model-a", "model-b", "model-c"]));
+
+        let lease0 = pool.acquire().await;
+        let lease1 = pool.acquire().await;
+        let lease2 = pool.acquire().await;
+
+        // Each lease should hold a different model
+        let mut indices = [
+            lease0.model_index(),
+            lease1.model_index(),
+            lease2.model_index(),
+        ];
+        indices.sort();
+        assert_eq!(indices, [0, 1, 2]);
+    }
+
+    #[tokio::test]
+    async fn test_acquire_waits_when_all_busy() {
+        use tokio::time::{Duration, timeout};
+
+        let pool = Arc::new(make_pool(&["model-a"]));
+
+        // Acquire the only permit.
+        let lease = pool.acquire().await;
+        assert_eq!(lease.model_index(), 0);
+
+        // A second acquire should time out because the single slot is held.
+        let pool_clone = Arc::clone(&pool);
+        let result = timeout(Duration::from_millis(50), async move {
+            pool_clone.acquire().await
+        })
+        .await;
+
+        assert!(
+            result.is_err(),
+            "acquire should have timed out while all models are busy"
+        );
+
+        // Drop the lease to release the permit.
+        drop(lease);
+
+        // Now we should be able to acquire again.
+        let lease2 = pool.acquire().await;
+        assert_eq!(lease2.model_index(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_acquire_preferred_waits_and_releases() {
+        use tokio::time::{Duration, timeout};
+
+        let pool = Arc::new(make_pool(&["model-a"]));
+
+        let lease = pool.acquire_preferred().await;
+        assert_eq!(lease.model_index(), 0);
+
+        let pool_clone = Arc::clone(&pool);
+        let result = timeout(Duration::from_millis(50), async move {
+            pool_clone.acquire_preferred().await
+        })
+        .await;
+
+        assert!(result.is_err(), "acquire_preferred should have timed out");
+        drop(lease);
+
+        // After release, acquiring preferred should succeed.
+        let lease2 = pool.acquire_preferred().await;
+        assert_eq!(lease2.model_index(), 0);
+    }
+}

--- a/src/prompt2gaql.rs
+++ b/src/prompt2gaql.rs
@@ -25,20 +25,46 @@ use crate::util::QueryEntry;
 pub struct LlmConfig {
     api_key: String,
     base_url: String,
-    model: String,
+    /// Ordered list of model names; index 0 is the preferred/primary model.
+    models: Vec<String>,
     temperature: f32,
 }
 
 impl LlmConfig {
+    /// Create a config from an explicit list of model names for unit tests.
+    ///
+    /// Uses placeholder values for all other fields so no real LLM calls are made.
+    #[cfg(test)]
+    pub fn from_models_for_test(models: Vec<String>) -> Self {
+        assert!(!models.is_empty(), "models must not be empty");
+        Self {
+            api_key: "dummy".to_string(),
+            base_url: "https://api.openai.com/v1".to_string(),
+            models,
+            temperature: 0.1,
+        }
+    }
+
     /// Create a dummy config for unit tests (does not make real LLM calls)
     #[cfg(test)]
     pub fn from_env_or_dummy() -> Self {
+        let models_str =
+            std::env::var("MCC_GAQL_LLM_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_string());
+        let models: Vec<String> = models_str
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let models = if models.is_empty() {
+            vec!["gpt-4o-mini".to_string()]
+        } else {
+            models
+        };
         Self {
             api_key: std::env::var("MCC_GAQL_LLM_API_KEY").unwrap_or_else(|_| "dummy".to_string()),
             base_url: std::env::var("MCC_GAQL_LLM_BASE_URL")
                 .unwrap_or_else(|_| "https://api.openai.com/v1".to_string()),
-            model: std::env::var("MCC_GAQL_LLM_MODEL")
-                .unwrap_or_else(|_| "gpt-4o-mini".to_string()),
+            models,
             temperature: 0.1,
         }
     }
@@ -53,10 +79,17 @@ impl LlmConfig {
         let base_url = std::env::var("MCC_GAQL_LLM_BASE_URL")
             .expect("MCC_GAQL_LLM_BASE_URL must be set (e.g., https://api.openai.com/v1 or https://openrouter.ai/api/v1)");
 
-        // Model: must be explicitly configured - fail fast if not set
-        let model = std::env::var("MCC_GAQL_LLM_MODEL").expect(
-            "MCC_GAQL_LLM_MODEL must be set (e.g., gpt-4o-mini or google/gemini-flash-2.0)",
-        );
+        // Models: comma-separated list; at least one required
+        let models: Vec<String> = std::env::var("MCC_GAQL_LLM_MODEL")
+            .expect("MCC_GAQL_LLM_MODEL must be set (e.g., gpt-4o-mini or google/gemini-flash-2.0)")
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if models.is_empty() {
+            panic!("MCC_GAQL_LLM_MODEL must contain at least one model name");
+        }
 
         // Temperature: default to 0.1 if not set, fail fast with explicit error if invalid
         let temperature: f32 = match std::env::var("MCC_GAQL_LLM_TEMPERATURE") {
@@ -72,31 +105,55 @@ impl LlmConfig {
         Self {
             api_key,
             base_url,
-            model,
+            models,
             temperature,
         }
     }
-}
 
-/// Create LLM completions client from config
-fn create_llm_client(config: &LlmConfig) -> Result<openai::CompletionsClient, anyhow::Error> {
-    openai::CompletionsClient::builder()
-        .api_key(&config.api_key)
-        .base_url(&config.base_url)
-        .build()
-        .map_err(|e| anyhow::anyhow!("Failed to create LLM client: {}", e))
+    /// Returns the first (preferred) model name.
+    pub fn preferred_model(&self) -> &str {
+        &self.models[0]
+    }
+
+    /// Returns all configured model names.
+    pub fn all_models(&self) -> &[String] {
+        &self.models
+    }
+
+    /// Returns the number of configured models.
+    pub fn model_count(&self) -> usize {
+        self.models.len()
+    }
 }
 
 impl LlmConfig {
-    /// Create a simple LLM agent suitable for direct prompt/response (no RAG).
-    /// Used by the metadata enricher and other modules that need LLM text generation.
+    /// Create an OpenAI-compatible completions client from this config.
+    pub fn create_llm_client(&self) -> Result<openai::CompletionsClient, anyhow::Error> {
+        openai::CompletionsClient::builder()
+            .api_key(&self.api_key)
+            .base_url(&self.base_url)
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to create LLM client: {}", e))
+    }
+
+    /// Create a simple LLM agent for the preferred (first) model with the given system prompt.
+    /// Used by callers that always want the primary model.
     pub fn create_agent(
         &self,
         system_prompt: &str,
     ) -> Result<Agent<CompletionModel>, anyhow::Error> {
-        let client = create_llm_client(self)?;
+        self.create_agent_for_model(self.preferred_model(), system_prompt)
+    }
+
+    /// Create a simple LLM agent for the specified model name with the given system prompt.
+    pub fn create_agent_for_model(
+        &self,
+        model: &str,
+        system_prompt: &str,
+    ) -> Result<Agent<CompletionModel>, anyhow::Error> {
+        let client = self.create_llm_client()?;
         let agent = client
-            .agent(&self.model)
+            .agent(model)
             .preamble(system_prompt)
             .temperature(self.temperature as f64)
             .build();
@@ -120,7 +177,7 @@ struct AgentResources {
 
 /// Initialize shared LLM resources used by both agent types
 fn init_llm_resources(config: &LlmConfig) -> Result<AgentResources, anyhow::Error> {
-    let llm_client = create_llm_client(config)?;
+    let llm_client = config.create_llm_client()?;
     let (embed_client, embedding_model) = create_embedding_client();
 
     Ok(AgentResources {
@@ -534,7 +591,11 @@ impl FieldDocument {
         };
 
         let id = field.name.clone();
-        Self { id, field, description }
+        Self {
+            id,
+            field,
+            description,
+        }
     }
 
     /// Generate a synthetic description for better semantic matching (fallback for unenriched fields)
@@ -650,7 +711,11 @@ impl RAGAgent {
         query_cookbook: Vec<QueryEntry>,
         config: &LlmConfig,
     ) -> Result<Self, anyhow::Error> {
-        log::info!("Using LLM: {} via {}", config.model, config.base_url);
+        log::info!(
+            "Using LLM: {} via {}",
+            config.preferred_model(),
+            config.base_url
+        );
 
         // Initialize shared LLM resources
         let resources = init_llm_resources(config)?;
@@ -661,7 +726,7 @@ impl RAGAgent {
 
         let agent = resources
             .llm_client
-            .agent(&config.model)
+            .agent(config.preferred_model())
             .preamble("
                 You are a Google Ads GAQL query assistant here to assist the user to translate natural language query requests into valid GAQL.
 
@@ -770,7 +835,11 @@ impl EnhancedRAGAgent {
     ) -> Result<Self, anyhow::Error> {
         let init_start = std::time::Instant::now();
 
-        log::info!("Using LLM: {} via {}", config.model, config.base_url);
+        log::info!(
+            "Using LLM: {} via {}",
+            config.preferred_model(),
+            config.base_url
+        );
 
         // Initialize shared LLM resources
         let resources = init_llm_resources(config)?;
@@ -800,7 +869,7 @@ impl EnhancedRAGAgent {
 
         let agent = resources
             .llm_client
-            .agent(&config.model)
+            .agent(config.preferred_model())
             .preamble(&preamble)
             .temperature(config.temperature as f64)
             .build();
@@ -1370,5 +1439,75 @@ mod tests {
 
         // Different queries should produce different hash
         assert_ne!(hash1, hash2, "Changing query should change hash");
+    }
+
+    // ── LlmConfig parsing tests ──────────────────────────────────────────────
+
+    /// Helper: build an `LlmConfig` from a raw `MCC_GAQL_LLM_MODEL` string,
+    /// using placeholder values for the other required fields.
+    fn make_config_from_model_str(model_str: &str) -> LlmConfig {
+        let models: Vec<String> = model_str
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        LlmConfig {
+            api_key: "dummy".to_string(),
+            base_url: "https://api.openai.com/v1".to_string(),
+            models,
+            temperature: 0.1,
+        }
+    }
+
+    #[test]
+    fn test_llm_config_single_model() {
+        let config = make_config_from_model_str("model-a");
+        assert_eq!(config.all_models(), &["model-a"]);
+        assert_eq!(config.preferred_model(), "model-a");
+        assert_eq!(config.model_count(), 1);
+    }
+
+    #[test]
+    fn test_llm_config_multiple_models() {
+        let config = make_config_from_model_str("model-a,model-b,model-c");
+        assert_eq!(config.all_models(), &["model-a", "model-b", "model-c"]);
+        assert_eq!(config.preferred_model(), "model-a");
+        assert_eq!(config.model_count(), 3);
+    }
+
+    #[test]
+    fn test_llm_config_whitespace_trimming() {
+        let config = make_config_from_model_str(" model-a , model-b ");
+        assert_eq!(config.all_models(), &["model-a", "model-b"]);
+        assert_eq!(config.preferred_model(), "model-a");
+        assert_eq!(config.model_count(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "MCC_GAQL_LLM_MODEL must contain at least one model name")]
+    fn test_llm_config_empty_panics() {
+        // Simulate what from_env() does when the value is empty
+        let models: Vec<String> = ""
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if models.is_empty() {
+            panic!("MCC_GAQL_LLM_MODEL must contain at least one model name");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "MCC_GAQL_LLM_MODEL must contain at least one model name")]
+    fn test_llm_config_only_commas_panics() {
+        // Simulate what from_env() does when value is ",,"
+        let models: Vec<String> = ",,"
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if models.is_empty() {
+            panic!("MCC_GAQL_LLM_MODEL must contain at least one model name");
+        }
     }
 }

--- a/tests/metadata_scraper_live_tests.rs
+++ b/tests/metadata_scraper_live_tests.rs
@@ -37,7 +37,10 @@ async fn test_live_scrape_campaign_resource() {
 
     // If we got docs, verify they look reasonable
     if !docs.docs.is_empty() {
-        println!("Scraped {} field docs from campaign resource", docs.docs.len());
+        println!(
+            "Scraped {} field docs from campaign resource",
+            docs.docs.len()
+        );
 
         // Print a sample of what we found
         for (field_name, field_doc) in docs.docs.iter().take(5) {
@@ -62,9 +65,7 @@ async fn test_live_scrape_multiple_resources() {
     ];
 
     let result = ScrapedDocs::scrape_all(
-        &resources,
-        "v19",
-        500, // Rate limit
+        &resources, "v19", 500, // Rate limit
     )
     .await;
 
@@ -88,22 +89,23 @@ async fn test_live_scrape_multiple_resources() {
 #[tokio::test]
 #[ignore]
 async fn test_live_skips_metrics_and_segments() {
-    let resources = vec![
-        "metrics".to_string(),
-        "segments".to_string(),
-    ];
+    let resources = vec!["metrics".to_string(), "segments".to_string()];
 
     let result = ScrapedDocs::scrape_all(
-        &resources,
-        "v19",
-        0, // No delay needed since no HTTP calls should be made
+        &resources, "v19", 0, // No delay needed since no HTTP calls should be made
     )
     .await;
 
     let docs = result.expect("Scraping metrics/segments should succeed (by skipping them)");
 
-    assert_eq!(docs.resources_scraped, 0, "metrics/segments should be skipped");
-    assert_eq!(docs.resources_skipped, 0, "Skipped prefixes don't count as 'skipped'");
+    assert_eq!(
+        docs.resources_scraped, 0,
+        "metrics/segments should be skipped"
+    );
+    assert_eq!(
+        docs.resources_skipped, 0,
+        "Skipped prefixes don't count as 'skipped'"
+    );
     assert!(docs.docs.is_empty(), "No docs should be extracted");
 }
 
@@ -127,7 +129,10 @@ async fn test_live_load_or_scrape_creates_cache() {
     let docs = result.expect("load_or_scrape should succeed");
 
     // Cache file should now exist
-    assert!(cache_path.exists(), "Cache file should be created after scraping");
+    assert!(
+        cache_path.exists(),
+        "Cache file should be created after scraping"
+    );
 
     println!(
         "Created cache with {} field docs at {:?}",
@@ -136,14 +141,8 @@ async fn test_live_load_or_scrape_creates_cache() {
     );
 
     // Second call should use the cache (no network needed)
-    let cached_result = ScrapedDocs::load_or_scrape(
-        &["campaign".to_string()],
-        "v19",
-        &cache_path,
-        30,
-        500,
-    )
-    .await;
+    let cached_result =
+        ScrapedDocs::load_or_scrape(&["campaign".to_string()], "v19", &cache_path, 30, 500).await;
 
     let cached_docs = cached_result.expect("Loading from cache should succeed");
     assert_eq!(
@@ -167,7 +166,10 @@ async fn test_live_handles_nonexistent_resource_gracefully() {
     let docs = result.expect("Scraping nonexistent resource should not error");
 
     assert_eq!(docs.resources_scraped, 0);
-    assert_eq!(docs.resources_skipped, 1, "Nonexistent resource should be counted as skipped");
+    assert_eq!(
+        docs.resources_skipped, 1,
+        "Nonexistent resource should be counted as skipped"
+    );
     assert!(docs.docs.is_empty());
 }
 
@@ -182,12 +184,7 @@ async fn test_live_comprehensive_scrape() {
         "keyword_view".to_string(),
     ];
 
-    let result = ScrapedDocs::scrape_all(
-        &resources,
-        "v19",
-        500,
-    )
-    .await;
+    let result = ScrapedDocs::scrape_all(&resources, "v19", 500).await;
 
     let docs = result.expect("Comprehensive scrape should succeed");
 
@@ -198,10 +195,14 @@ async fn test_live_comprehensive_scrape() {
     println!("Total field docs: {}", docs.docs.len());
 
     // Group docs by resource prefix
-    let mut by_resource: std::collections::HashMap<String, Vec<&str>> = std::collections::HashMap::new();
+    let mut by_resource: std::collections::HashMap<String, Vec<&str>> =
+        std::collections::HashMap::new();
     for field_name in docs.docs.keys() {
         let resource = field_name.split('.').next().unwrap_or("unknown");
-        by_resource.entry(resource.to_string()).or_default().push(field_name);
+        by_resource
+            .entry(resource.to_string())
+            .or_default()
+            .push(field_name);
     }
 
     println!("\nFields per resource:");
@@ -225,10 +226,13 @@ async fn test_live_comprehensive_scrape() {
     }
 
     // Check for enum values in status fields
-    if let Some(status_doc) = docs.docs.get("campaign.status") {
-        if !status_doc.enum_values.is_empty() {
-            println!("\ncampaign.status enum values: {:?}", status_doc.enum_values);
-        }
+    if let Some(status_doc) = docs.docs.get("campaign.status")
+        && !status_doc.enum_values.is_empty()
+    {
+        println!(
+            "\ncampaign.status enum values: {:?}",
+            status_doc.enum_values
+        );
     }
 
     // At minimum, we should have scraped something

--- a/tests/metadata_scraper_tests.rs
+++ b/tests/metadata_scraper_tests.rs
@@ -168,7 +168,9 @@ fn test_parse_field_docs_extracts_description() {
     let html = campaign_html();
     let docs = ScrapedDocs::parse_field_docs("campaign", &html);
 
-    let name_doc = docs.get("campaign.name").expect("campaign.name should be found");
+    let name_doc = docs
+        .get("campaign.name")
+        .expect("campaign.name should be found");
     assert!(
         name_doc.description.contains("name of the campaign"),
         "Expected description to mention 'name of the campaign', got: {:?}",
@@ -181,7 +183,9 @@ fn test_parse_field_docs_extracts_enum_values() {
     let html = campaign_html();
     let docs = ScrapedDocs::parse_field_docs("campaign", &html);
 
-    let status_doc = docs.get("campaign.status").expect("campaign.status should be found");
+    let status_doc = docs
+        .get("campaign.status")
+        .expect("campaign.status should be found");
     assert!(
         status_doc.enum_values.contains(&"ENABLED".to_string()),
         "Expected ENABLED in enum_values, got: {:?}",
@@ -203,13 +207,22 @@ fn test_parse_field_docs_handles_multiple_fields() {
     let docs = ScrapedDocs::parse_field_docs("campaign", &html);
 
     // Should find all four fields from the fixture
-    assert!(docs.contains_key("campaign.name"), "Should contain campaign.name");
-    assert!(docs.contains_key("campaign.status"), "Should contain campaign.status");
+    assert!(
+        docs.contains_key("campaign.name"),
+        "Should contain campaign.name"
+    );
+    assert!(
+        docs.contains_key("campaign.status"),
+        "Should contain campaign.status"
+    );
     assert!(
         docs.contains_key("campaign.advertising_channel_type"),
         "Should contain campaign.advertising_channel_type"
     );
-    assert!(docs.contains_key("campaign.id"), "Should contain campaign.id");
+    assert!(
+        docs.contains_key("campaign.id"),
+        "Should contain campaign.id"
+    );
 }
 
 #[test]
@@ -335,7 +348,9 @@ async fn test_load_from_disk_fails_gracefully_on_missing_file() {
 async fn test_load_from_disk_fails_gracefully_on_corrupt_json() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("corrupt.json");
-    tokio::fs::write(&path, b"{ not valid json }").await.unwrap();
+    tokio::fs::write(&path, b"{ not valid json }")
+        .await
+        .unwrap();
     let result = ScrapedDocs::load_from_disk(&path).await;
     assert!(result.is_err(), "Corrupt JSON should return an error");
 }
@@ -371,8 +386,8 @@ async fn test_load_or_scrape_returns_cached_when_fresh() {
         &["campaign".to_string()],
         "v23",
         &path,
-        30,  // 30-day TTL
-        0,   // no delay
+        30, // 30-day TTL
+        0,  // no delay
     )
     .await
     .unwrap();
@@ -402,20 +417,13 @@ async fn test_load_or_scrape_rescapes_when_stale() {
 
     // Start a mock server that returns valid HTML
     let mut responses = HashMap::new();
-    responses.insert(
-        "/v23/campaign".to_string(),
-        (200, campaign_html()),
-    );
+    responses.insert("/v23/campaign".to_string(), (200, campaign_html()));
     let base_url = start_mock_server(responses, 5).await;
 
-    let result = ScrapedDocs::scrape_all_with_base_url(
-        &["campaign".to_string()],
-        "v23",
-        0,
-        &base_url,
-    )
-    .await
-    .unwrap();
+    let result =
+        ScrapedDocs::scrape_all_with_base_url(&["campaign".to_string()], "v23", 0, &base_url)
+            .await
+            .unwrap();
 
     // The fresh scrape should have found content
     assert!(
@@ -445,7 +453,10 @@ async fn test_scrape_all_with_mock_server_extracts_fields() {
     .unwrap();
 
     assert_eq!(result.api_version, "v23");
-    assert_eq!(result.resources_scraped, 1, "One resource should be scraped");
+    assert_eq!(
+        result.resources_scraped, 1,
+        "One resource should be scraped"
+    );
     assert_eq!(result.resources_skipped, 0);
     assert!(
         !result.docs.is_empty(),
@@ -469,14 +480,10 @@ async fn test_scrape_all_extracts_enum_values_via_mock() {
 
     let base_url = start_mock_server(responses, 5).await;
 
-    let result = ScrapedDocs::scrape_all_with_base_url(
-        &["campaign".to_string()],
-        "v23",
-        0,
-        &base_url,
-    )
-    .await
-    .unwrap();
+    let result =
+        ScrapedDocs::scrape_all_with_base_url(&["campaign".to_string()], "v23", 0, &base_url)
+            .await
+            .unwrap();
 
     let status_enums = result
         .get_enum_values("campaign.status")
@@ -493,18 +500,23 @@ async fn test_scrape_all_handles_404_gracefully() {
 
     let base_url = start_mock_server(responses, 5).await;
 
-    let result = ScrapedDocs::scrape_all_with_base_url(
-        &["campaign".to_string()],
-        "v23",
-        0,
-        &base_url,
-    )
-    .await
-    .unwrap();
+    let result =
+        ScrapedDocs::scrape_all_with_base_url(&["campaign".to_string()], "v23", 0, &base_url)
+            .await
+            .unwrap();
 
-    assert_eq!(result.resources_scraped, 0, "404 page should not count as scraped");
-    assert_eq!(result.resources_skipped, 1, "404 page should be counted as skipped");
-    assert!(result.docs.is_empty(), "No docs should be extracted from a 404");
+    assert_eq!(
+        result.resources_scraped, 0,
+        "404 page should not count as scraped"
+    );
+    assert_eq!(
+        result.resources_skipped, 1,
+        "404 page should be counted as skipped"
+    );
+    assert!(
+        result.docs.is_empty(),
+        "No docs should be extracted from a 404"
+    );
 }
 
 #[tokio::test]
@@ -514,16 +526,15 @@ async fn test_scrape_all_handles_too_small_page_gracefully() {
 
     let base_url = start_mock_server(responses, 5).await;
 
-    let result = ScrapedDocs::scrape_all_with_base_url(
-        &["campaign".to_string()],
-        "v23",
-        0,
-        &base_url,
-    )
-    .await
-    .unwrap();
+    let result =
+        ScrapedDocs::scrape_all_with_base_url(&["campaign".to_string()], "v23", 0, &base_url)
+            .await
+            .unwrap();
 
-    assert_eq!(result.resources_scraped, 0, "Tiny page should not count as scraped");
+    assert_eq!(
+        result.resources_scraped, 0,
+        "Tiny page should not count as scraped"
+    );
     assert_eq!(result.resources_skipped, 1);
     assert!(result.docs.is_empty());
 }
@@ -535,14 +546,10 @@ async fn test_scrape_all_handles_large_unrelated_page_gracefully() {
 
     let base_url = start_mock_server(responses, 5).await;
 
-    let result = ScrapedDocs::scrape_all_with_base_url(
-        &["campaign".to_string()],
-        "v23",
-        0,
-        &base_url,
-    )
-    .await
-    .unwrap();
+    let result =
+        ScrapedDocs::scrape_all_with_base_url(&["campaign".to_string()], "v23", 0, &base_url)
+            .await
+            .unwrap();
 
     // Large but no "google-ads" marker → scraper skips the page
     assert_eq!(result.resources_scraped, 0);
@@ -569,7 +576,10 @@ async fn test_scrape_all_skips_metrics_prefix() {
 
     assert_eq!(result.resources_scraped, 0);
     // Metrics/segments are skipped before making any HTTP call → skipped count stays 0
-    assert_eq!(result.resources_skipped, 0, "Skipped resources should not count as 'skipped' when they bypass HTTP entirely");
+    assert_eq!(
+        result.resources_skipped, 0,
+        "Skipped resources should not count as 'skipped' when they bypass HTTP entirely"
+    );
     assert!(result.docs.is_empty());
 }
 
@@ -591,7 +601,10 @@ async fn test_scrape_all_processes_multiple_resources() {
     .await
     .unwrap();
 
-    assert_eq!(result.resources_scraped, 2, "Both resources should be scraped");
+    assert_eq!(
+        result.resources_scraped, 2,
+        "Both resources should be scraped"
+    );
     assert!(result.docs.contains_key("campaign.name"));
     assert!(result.docs.contains_key("ad_group.name"));
     assert!(result.docs.contains_key("ad_group.status"));
@@ -616,7 +629,10 @@ async fn test_scrape_all_partial_failure_continues() {
     .unwrap();
 
     assert_eq!(result.resources_scraped, 1, "campaign should be scraped");
-    assert_eq!(result.resources_skipped, 1, "ad_group should be skipped (404)");
+    assert_eq!(
+        result.resources_skipped, 1,
+        "ad_group should be skipped (404)"
+    );
     assert!(result.docs.contains_key("campaign.name"));
     assert!(!result.docs.contains_key("ad_group.name"));
 }


### PR DESCRIPTION
## Summary

This PR implements multi-model concurrency support for the metadata enrichment pipeline, allowing multiple LLM models to work in parallel for faster field description generation.

## Changes

- **New `ModelPool` struct** (`src/model_pool.rs`): Manages a pool of LLM models with per-model semaphore-based concurrency control
- **Enhanced `LlmConfig`**: Now parses comma-separated model lists from `MCC_GAQL_LLM_MODEL`
- **Updated `MetadataEnricher`**: Distributes enrichment batches across all available models
- **Concurrency model**: One request per model at a time (configurable via model count)

## Usage

```bash
# Single model (backward compatible)
export MCC_GAQL_LLM_MODEL="google/gemini-flash-2.0"

# Multiple models for concurrent processing
export MCC_GAQL_LLM_MODEL="google/gemini-flash-2.0,openai/gpt-4o-mini,anthropic/claude-3-haiku"
```

## Testing

- All 108 existing tests pass
- Added comprehensive unit tests for `ModelPool` acquisition strategies
- Verified backward compatibility with single-model configurations

## Architecture

```
┌─────────────────┐     ┌──────────────┐     ┌─────────────────┐
│ MetadataEnricher│────▶│  ModelPool   │────▶│  ModelLease     │
└─────────────────┘     └──────────────┘     └─────────────────┘
                              │
        ┌─────────────────────┼─────────────────────┐
        ▼                     ▼                     ▼
   ┌─────────┐          ┌─────────┐          ┌─────────┐
   │ Model 0 │          │ Model 1 │          │ Model N │
   │(sem=1)  │          │(sem=1)  │          │(sem=1)  │
   └─────────┘          └─────────┘          └─────────┘
```

## Checklist

- [x] Code compiles without warnings
- [x] All tests pass
- [x] Backward compatible with existing configurations
- [x] New functionality documented in code