### PR TITLE
Fix: mcc-gaql-gen Should Auto-Discover Query Cookbook

### DIFF
--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -326,11 +326,27 @@ async fn cmd_generate(
 
     // Load query cookbook
     let example_queries: Vec<QueryEntry> = if let Some(queries_file) = queries {
+        // Explicit --queries flag provided
         let queries_path = config_file_path(&queries_file)
             .with_context(|| format!("Could not find queries file: {}", queries_file))?;
         println!("Loading query cookbook from {:?}...", queries_path);
         let map = get_queries_from_file(&queries_path).await?;
         map.into_values().collect()
+    } else if let Some(default_path) = config_file_path("query_cookbook.toml") {
+        // Try to auto-discover query_cookbook.toml in config directory
+        if default_path.exists() {
+            println!("Loading query cookbook from {:?}...", default_path);
+            match get_queries_from_file(&default_path).await {
+                Ok(map) => map.into_values().collect(),
+                Err(e) => {
+                    log::warn!("Failed to load query cookbook: {}", e);
+                    Vec::new()
+                }
+            }
+        } else {
+            println!("No query cookbook found. Using enhanced field metadata only.");
+            Vec::new()
+        }
     } else {
         println!("No query cookbook specified. Using enhanced field metadata only.");
         Vec::new()


### PR DESCRIPTION
## Summary

`mcc-gaql-gen generate` now auto-discovers `query_cookbook.toml` from the standard config directory when `--queries` is not provided.

## Problem

Previously, `mcc-gaql-gen generate` would only load the query cookbook when the `--queries` flag was explicitly provided. If omitted, it would print "No query cookbook specified. Using enhanced field metadata only." and proceed without example queries.

Meanwhile, `mcc-gaql` already had automatic discovery of `query_cookbook.toml` via its profile-based config system.

## Solution

Modified `cmd_generate()` in `crates/mcc-gaql-gen/src/main.rs` to:

1. If `--queries` is provided → use that file path (existing behavior)
2. If `--queries` is not provided → try to load `query_cookbook.toml` from the config directory
3. If the file doesn't exist → print message and continue with empty examples (existing behavior)

## Changes

- `crates/mcc-gaql-gen/src/main.rs`: Updated query cookbook loading logic with auto-discovery fallback

## Testing

- All 32 unit tests pass
- 8/9 integration tests pass (1 flaky test failure unrelated to this change)
- Verified code compiles with `cargo check -p mcc-gaql-gen`