### PR TITLE
feat: RAG pipeline improvements - timing instrumentation, clean output, test isolation

### DIFF
--- a/crates/mcc-gaql-common/src/config.rs
+++ b/crates/mcc-gaql-common/src/config.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use toml::Value;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
+use toml::Value;
 
 pub const TOML_CONFIG_FILENAME: &str = "config.toml";
 pub const ENV_VAR_PREFIX: &str = "MCC_GAQL_";
@@ -192,15 +192,14 @@ where
                 }
 
                 // Validate and normalize customer ID
-                let normalized = validate_and_normalize_customer_id(trimmed)
-                    .map_err(|e| {
-                        anyhow::anyhow!(
-                            "Invalid customer ID on line {} in file {}: {}",
-                            line_num + 1,
-                            filename.as_ref().display(),
-                            e
-                        )
-                    })?;
+                let normalized = validate_and_normalize_customer_id(trimmed).map_err(|e| {
+                    anyhow::anyhow!(
+                        "Invalid customer ID on line {} in file {}: {}",
+                        line_num + 1,
+                        filename.as_ref().display(),
+                        e
+                    )
+                })?;
 
                 customer_ids.push(normalized);
             }

--- a/crates/mcc-gaql-common/src/field_metadata.rs
+++ b/crates/mcc-gaql-common/src/field_metadata.rs
@@ -61,10 +61,7 @@ impl FieldMetadata {
     /// Get the resource name for this field (e.g., "campaign" from "campaign.name")
     pub fn get_resource(&self) -> Option<String> {
         if let Some(_idx) = self.name.find('.') {
-            self.name
-                .split('.')
-                .next()
-                .map(|s| s.to_string())
+            self.name.split('.').next().map(|s| s.to_string())
         } else {
             None
         }
@@ -319,7 +316,8 @@ impl FieldMetadataCache {
 
         // Filter fields - only keep fields belonging to retained resources
         self.fields.retain(|_, field| {
-            field.get_resource()
+            field
+                .get_resource()
                 .map(|r| keep_set.contains(&r))
                 .unwrap_or(false)
         });
@@ -520,9 +518,11 @@ impl FieldMetadataCache {
         if resource_selectable_with.is_empty() {
             // No RESOURCE field found for this resource - compatibility check skipped
             // This could indicate metadata is not fully enriched
-            result.warnings.push(ValidationWarning::MissingResourceSelectableWith {
-                resource: from_resource.to_string(),
-            });
+            result
+                .warnings
+                .push(ValidationWarning::MissingResourceSelectableWith {
+                    resource: from_resource.to_string(),
+                });
             return result;
         }
 
@@ -638,7 +638,10 @@ pub struct ValidationResult {
 pub enum ValidationError {
     UnknownFields(Vec<String>),
     NonSelectableFields(Vec<String>),
-    IncompatibleFields { fields: Vec<String>, resource: String },
+    IncompatibleFields {
+        fields: Vec<String>,
+        resource: String,
+    },
 }
 
 impl std::fmt::Display for ValidationError {
@@ -704,11 +707,18 @@ pub struct PipelineTrace {
     pub phase1_related_resources: Vec<String>,
     pub phase1_dropped_resources: Vec<String>,
     pub phase1_reasoning: String,
+    pub phase1_model_used: String,
+    pub phase1_timing_ms: u64,
     pub phase2_candidate_count: usize,
     pub phase2_rejected_count: usize,
+    pub phase2_timing_ms: u64,
+    pub phase25_pre_scan_filters: Vec<(String, Vec<String>)>, // (field_name, detected_enum_values)
     pub phase3_selected_fields: Vec<String>,
     pub phase3_filter_fields: Vec<FilterField>,
     pub phase3_order_by_fields: Vec<(String, String)>, // (field_name, direction)
+    pub phase3_reasoning: String,
+    pub phase3_model_used: String,
+    pub phase3_timing_ms: u64,
     pub phase4_where_clauses: Vec<String>,
     pub phase4_during: Option<String>,
     pub phase4_limit: Option<u32>,
@@ -857,10 +867,7 @@ mod tests {
             "campaign".to_string(),
             vec!["campaign.id".to_string(), "campaign.name".to_string()],
         );
-        resources.insert(
-            "ad_group".to_string(),
-            vec!["ad_group.id".to_string()],
-        );
+        resources.insert("ad_group".to_string(), vec!["ad_group.id".to_string()]);
         resources.insert("customer".to_string(), vec!["customer.id".to_string()]);
         cache.resources = Some(resources);
 
@@ -1066,10 +1073,7 @@ mod tests {
                 sortable: false,
                 metrics_compatible: true,
                 resource_name: None,
-                selectable_with: vec![
-                    "campaign".to_string(),
-                    "metrics.clicks".to_string(),
-                ],
+                selectable_with: vec!["campaign".to_string(), "metrics.clicks".to_string()],
                 enum_values: vec![],
                 attribute_resources: vec![],
                 description: None,
@@ -1104,10 +1108,12 @@ mod tests {
         );
 
         assert!(result.is_valid);
-        assert!(!result.errors.iter().any(|e| matches!(
-            e,
-            ValidationError::IncompatibleFields { .. }
-        )));
+        assert!(
+            !result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::IncompatibleFields { .. }))
+        );
     }
 
     #[test]

--- a/crates/mcc-gaql-common/src/paths.rs
+++ b/crates/mcc-gaql-common/src/paths.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::path::PathBuf;
 
 const CRATE_NAME: &str = "mcc-gaql";

--- a/crates/mcc-gaql-gen/src/enricher.rs
+++ b/crates/mcc-gaql-gen/src/enricher.rs
@@ -20,8 +20,8 @@ use mcc_gaql_common::field_metadata::{FieldMetadata, FieldMetadataCache, Resourc
 
 use crate::rag::format_llm_request_debug;
 
-use crate::scraper::ScrapedDocs;
 use crate::model_pool::{ModelLease, ModelPool};
+use crate::scraper::ScrapedDocs;
 
 /// LLM-based enricher for Google Ads field metadata
 pub struct MetadataEnricher {
@@ -171,10 +171,7 @@ impl MetadataEnricher {
         }
 
         // Stage 3: Key field selection per resource (run before resource description enrichment)
-        log::info!(
-            "Selecting key fields for {} resources",
-            resources.len()
-        );
+        log::info!("Selecting key fields for {} resources", resources.len());
         for resource in &resources {
             match self.select_key_fields_for_resource(resource, cache).await {
                 Ok((key_attrs, key_mets)) => {
@@ -188,11 +185,7 @@ impl MetadataEnricher {
                     }
                 }
                 Err(e) => {
-                    log::warn!(
-                        "  Key field selection failed for '{}': {}",
-                        resource,
-                        e
-                    );
+                    log::warn!("  Key field selection failed for '{}': {}", resource, e);
                 }
             }
         }
@@ -377,10 +370,7 @@ Use in SELECT to label rows in reports.\",\n\
                         .map(String::as_str)
                         .collect();
                     if !descs.is_empty() {
-                        prompt.push_str(&format!(
-                            "  Enum descriptions: {}\n",
-                            descs.join("; ")
-                        ));
+                        prompt.push_str(&format!("  Enum descriptions: {}\n", descs.join("; ")));
                     }
                 }
             }
@@ -590,7 +580,11 @@ Do NOT include fields that are rarely used or very specialized.";
 
         let llm_start = std::time::Instant::now();
         let response = agent.prompt(&user_prompt).await.map_err(|e| {
-            anyhow::anyhow!("LLM prompt failed for key field selection on {}: {}", resource, e)
+            anyhow::anyhow!(
+                "LLM prompt failed for key field selection on {}: {}",
+                resource,
+                e
+            )
         })?;
         log::debug!(
             "Key field selection LLM (model={}) responded in {}ms",
@@ -600,9 +594,8 @@ Do NOT include fields that are rarely used or very specialized.";
 
         // Parse JSON response (strip markdown fences first)
         let cleaned_response = strip_json_fences(&response);
-        let parsed: serde_json::Value = serde_json::from_str(&cleaned_response).map_err(|e| {
-            anyhow::anyhow!("Failed to parse LLM response as JSON: {}", e)
-        })?;
+        let parsed: serde_json::Value = serde_json::from_str(&cleaned_response)
+            .map_err(|e| anyhow::anyhow!("Failed to parse LLM response as JSON: {}", e))?;
 
         let mut key_attributes: Vec<String> = parsed
             .get("key_attributes")

--- a/crates/mcc-gaql-gen/src/enricher.rs
+++ b/crates/mcc-gaql-gen/src/enricher.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 
 use mcc_gaql_common::field_metadata::{FieldMetadata, FieldMetadataCache, ResourceMetadata};
 
+use crate::rag::format_llm_request_debug;
+
 use crate::scraper::ScrapedDocs;
 use crate::model_pool::{ModelLease, ModelPool};
 
@@ -265,14 +267,31 @@ Use in SELECT to label rows in reports.\",\n\
 
         let user_prompt = Self::build_batch_prompt_static(resource, fields, scraped);
 
+        log::debug!(
+            "Enriching {} fields (model={}, temp={})",
+            fields.len(),
+            lease.model_name(),
+            lease.temperature()
+        );
+        log::trace!(
+            "{}",
+            format_llm_request_debug(&Some(system_prompt.to_string()), &user_prompt)
+        );
+
         let agent = lease
             .create_agent(system_prompt)
             .context("Failed to create LLM agent for enrichment")?;
 
+        let llm_start = std::time::Instant::now();
         let response = agent
             .prompt(&user_prompt)
             .await
             .map_err(|e| anyhow::anyhow!("LLM prompt failed: {}", e))?;
+        log::debug!(
+            "Enrichment LLM (model={}) responded in {}ms",
+            lease.model_name(),
+            llm_start.elapsed().as_millis()
+        );
 
         Self::parse_enrichment_response_static(&response)
     }
@@ -463,13 +482,30 @@ used to query. Return ONLY the sentence, no formatting.";
         }
 
         let lease = self.model_pool.acquire_preferred().await;
+        log::debug!(
+            "Enriching resource {} (model={}, temp={})",
+            resource_name,
+            lease.model_name(),
+            lease.temperature()
+        );
+        log::trace!(
+            "{}",
+            format_llm_request_debug(&Some(system_prompt.to_string()), &user_prompt)
+        );
+
         let agent = lease
             .create_agent(system_prompt)
             .context("Failed to create LLM agent for resource enrichment")?;
 
+        let llm_start = std::time::Instant::now();
         let response = agent.prompt(&user_prompt).await.map_err(|e| {
             anyhow::anyhow!("LLM prompt failed for resource {}: {}", resource_name, e)
         })?;
+        log::debug!(
+            "Resource enrichment LLM (model={}) responded in {}ms",
+            lease.model_name(),
+            llm_start.elapsed().as_millis()
+        );
 
         Ok(response.trim().to_string())
     }
@@ -537,13 +573,30 @@ Do NOT include fields that are rarely used or very specialized.";
         user_prompt.push_str("Return JSON: {\"key_attributes\": [...], \"key_metrics\": [...]}");
 
         let lease = self.model_pool.acquire_preferred().await;
+        log::debug!(
+            "Selecting key fields for {} (model={}, temp={})",
+            resource,
+            lease.model_name(),
+            lease.temperature()
+        );
+        log::trace!(
+            "{}",
+            format_llm_request_debug(&Some(system_prompt.to_string()), &user_prompt)
+        );
+
         let agent = lease
             .create_agent(system_prompt)
             .context("Failed to create LLM agent for key field selection")?;
 
+        let llm_start = std::time::Instant::now();
         let response = agent.prompt(&user_prompt).await.map_err(|e| {
             anyhow::anyhow!("LLM prompt failed for key field selection on {}: {}", resource, e)
         })?;
+        log::debug!(
+            "Key field selection LLM (model={}) responded in {}ms",
+            lease.model_name(),
+            llm_start.elapsed().as_millis()
+        );
 
         // Parse JSON response (strip markdown fences first)
         let cleaned_response = strip_json_fences(&response);

--- a/crates/mcc-gaql-gen/src/lib.rs
+++ b/crates/mcc-gaql-gen/src/lib.rs
@@ -2,9 +2,9 @@
 #![recursion_limit = "512"]
 pub mod enricher;
 pub mod model_pool;
+pub mod proto_docs_cache;
 pub mod proto_locator;
 pub mod proto_parser;
-pub mod proto_docs_cache;
 pub mod r2;
 pub mod rag;
 // ScrapedDocs is still used as a data structure for field documentation,

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -43,6 +43,10 @@ struct Cli {
     #[arg(short, long)]
     verbose: bool,
 
+    /// Enable trace logging (includes full LLM prompts)
+    #[arg(long)]
+    trace: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -182,7 +186,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Initialize logging
-    init_logger(cli.verbose);
+    init_logger(cli.verbose, cli.trace);
 
     match cli.command {
         Commands::Scrape {
@@ -812,10 +816,12 @@ fn validate_llm_env() -> Result<()> {
 }
 
 /// Initialize logging based on verbosity and environment variables
-fn init_logger(verbose: bool) {
+fn init_logger(verbose: bool, trace: bool) {
     use flexi_logger::{Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
 
-    let base_level = if verbose {
+    let base_level = if trace {
+        "trace".to_string()
+    } else if verbose {
         "debug".to_string()
     } else {
         env::var("MCC_GAQL_LOG_LEVEL").unwrap_or_else(|_| "warn".to_string())

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -123,6 +123,10 @@ enum Commands {
         /// Skip implicit default filters (e.g., status = ENABLED)
         #[arg(long)]
         no_defaults: bool,
+
+        /// Enable RAG search for query cookbook examples in LLM prompts
+        #[arg(long)]
+        use_query_cookbook: bool,
     },
 
     /// Upload enriched metadata to Cloudflare R2
@@ -223,8 +227,9 @@ async fn main() -> Result<()> {
             queries,
             metadata,
             no_defaults,
+            use_query_cookbook,
         } => {
-            cmd_generate(prompt, queries, metadata, no_defaults, cli.verbose).await?;
+            cmd_generate(prompt, queries, metadata, no_defaults, use_query_cookbook, cli.verbose).await?;
         }
 
         Commands::Upload { file, key } => {
@@ -515,6 +520,7 @@ async fn cmd_generate(
     queries: Option<String>,
     metadata: Option<PathBuf>,
     no_defaults: bool,
+    use_query_cookbook: bool,
     verbose: bool,
 ) -> Result<()> {
     validate_llm_env()?;
@@ -587,6 +593,7 @@ async fn cmd_generate(
     // Build pipeline config
     let pipeline_config = rag::PipelineConfig {
         add_defaults: !no_defaults,
+        use_query_cookbook,
     };
 
     // Generate GAQL using MultiStepRAGAgent

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -815,15 +815,20 @@ fn validate_llm_env() -> Result<()> {
 fn init_logger(verbose: bool) {
     use flexi_logger::{Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
 
-    let log_level = if verbose {
+    let base_level = if verbose {
         "debug".to_string()
     } else {
         env::var("MCC_GAQL_LOG_LEVEL").unwrap_or_else(|_| "warn".to_string())
     };
 
+    // Suppress LanceDB deprecation warning about _distance column auto-projection
+    // This is an upstream issue in rig-lancedb: https://github.com/0xPlaygrounds/rig/issues/XXX
+    // The warning is harmless - _distance is still being included via auto-projection
+    let log_spec = format!("{}, lance::dataset::scanner=error", base_level);
+
     let log_dir = env::var("MCC_GAQL_LOG_DIR").unwrap_or_else(|_| ".".to_string());
 
-    Logger::try_with_env_or_str(log_level)
+    Logger::try_with_env_or_str(&log_spec)
         .unwrap()
         .use_utc()
         .log_to_file(

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -5,26 +5,21 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
-use mcc_gaql_gen::enricher as enricher;
-use mcc_gaql_gen::model_pool as model_pool;
-use mcc_gaql_gen::proto_locator as proto_locator;
-use mcc_gaql_gen::proto_docs_cache as proto_docs_cache;
-use mcc_gaql_gen::r2 as r2;
-use mcc_gaql_gen::rag as rag;
-use mcc_gaql_gen::scraper as scraper;
-use mcc_gaql_gen::vector_store as vector_store;
+use mcc_gaql_gen::enricher;
+use mcc_gaql_gen::model_pool;
+use mcc_gaql_gen::proto_docs_cache;
+use mcc_gaql_gen::proto_locator;
+use mcc_gaql_gen::r2;
+use mcc_gaql_gen::rag;
+use mcc_gaql_gen::scraper;
+use mcc_gaql_gen::vector_store;
 
-use mcc_gaql_common::config::{get_queries_from_file, QueryEntry};
+use mcc_gaql_common::config::{QueryEntry, get_queries_from_file};
 use mcc_gaql_common::field_metadata::FieldMetadataCache;
 use mcc_gaql_common::paths::config_file_path;
 
 /// Core resources for test-run mode
-const TEST_RUN_RESOURCES: &[&str] = &[
-    "campaign",
-    "ad_group",
-    "ad_group_ad",
-    "ad_group_criterion",
-];
+const TEST_RUN_RESOURCES: &[&str] = &["campaign", "ad_group", "ad_group_ad", "ad_group_criterion"];
 
 /// Filter resources for test-run mode
 fn filter_test_resources(resources: Vec<String>) -> Vec<String> {
@@ -127,6 +122,10 @@ enum Commands {
         /// Enable RAG search for query cookbook examples in LLM prompts
         #[arg(long)]
         use_query_cookbook: bool,
+
+        /// Print explanation of the LLM selection process to stdout
+        #[arg(long)]
+        explain_selection_process: bool,
     },
 
     /// Upload enriched metadata to Cloudflare R2
@@ -228,8 +227,18 @@ async fn main() -> Result<()> {
             metadata,
             no_defaults,
             use_query_cookbook,
+            explain_selection_process,
         } => {
-            cmd_generate(prompt, queries, metadata, no_defaults, use_query_cookbook, cli.verbose).await?;
+            cmd_generate(
+                prompt,
+                queries,
+                metadata,
+                no_defaults,
+                use_query_cookbook,
+                explain_selection_process,
+                cli.verbose,
+            )
+            .await?;
         }
 
         Commands::Upload { file, key } => {
@@ -276,7 +285,9 @@ async fn cmd_scrape(
     println!("Loading field metadata from {:?}...", cache_path);
     let cache = FieldMetadataCache::load_from_disk(&cache_path)
         .await
-        .context("Failed to load field metadata cache. Run 'mcc-gaql --refresh-field-cache' first.")?;
+        .context(
+            "Failed to load field metadata cache. Run 'mcc-gaql --refresh-field-cache' first.",
+        )?;
 
     let mut resources = cache.get_resources();
 
@@ -339,7 +350,9 @@ async fn cmd_enrich(
     println!("Loading field metadata from {:?}...", cache_path);
     let mut cache = FieldMetadataCache::load_from_disk(&cache_path)
         .await
-        .context("Failed to load field metadata cache. Run 'mcc-gaql --refresh-field-cache' first.")?;
+        .context(
+            "Failed to load field metadata cache. Run 'mcc-gaql --refresh-field-cache' first.",
+        )?;
 
     // Filter resources in cache for test-run mode BEFORE enrichment
     if test_run {
@@ -440,10 +453,7 @@ async fn cmd_enrich(
 }
 
 /// Proto-based enrichment: use proto documentation instead of LLM
-async fn cmd_enrich_proto(
-    cache: &mut FieldMetadataCache,
-    output: Option<PathBuf>,
-) -> Result<()> {
+async fn cmd_enrich_proto(cache: &mut FieldMetadataCache, output: Option<PathBuf>) -> Result<()> {
     // Stage 1: Load or build proto docs cache
     println!("\nStage 1/2: Loading proto documentation...");
 
@@ -464,9 +474,7 @@ async fn cmd_enrich_proto(
     let proto_stats = proto_cache.stats();
     println!(
         "Loaded proto docs: {} messages, {} fields, {} enums",
-        proto_stats.message_count,
-        proto_stats.field_count,
-        proto_stats.enum_count
+        proto_stats.message_count, proto_stats.field_count, proto_stats.enum_count
     );
 
     // Stage 2: Merge proto docs into field metadata
@@ -477,8 +485,7 @@ async fn cmd_enrich_proto(
     let total_fields = cache.fields.len();
     println!(
         "Proto enrichment complete: {}/{} fields enriched",
-        enriched_count,
-        total_fields
+        enriched_count, total_fields
     );
 
     // Count how many resources got descriptions
@@ -507,8 +514,7 @@ async fn cmd_enrich_proto(
 
     println!(
         "\nEnrichment complete. {}/{} fields enriched.",
-        enriched_count,
-        total_fields
+        enriched_count, total_fields
     );
 
     Ok(())
@@ -521,6 +527,7 @@ async fn cmd_generate(
     metadata: Option<PathBuf>,
     no_defaults: bool,
     use_query_cookbook: bool,
+    explain_selection_process: bool,
     verbose: bool,
 ) -> Result<()> {
     validate_llm_env()?;
@@ -562,13 +569,18 @@ async fn cmd_generate(
     log::info!("Loading field metadata from {:?}...", metadata_path);
     let field_cache = FieldMetadataCache::load_from_disk(&metadata_path)
         .await
-        .context("Failed to load field metadata. Run 'mcc-gaql-gen enrich' first or use --metadata.")?;
+        .context(
+            "Failed to load field metadata. Run 'mcc-gaql-gen enrich' first or use --metadata.",
+        )?;
 
     // Check if metadata is enriched (has resource_metadata with key_fields)
     let is_enriched = field_cache
         .resource_metadata
         .as_ref()
-        .map(|m| m.values().any(|rm| !rm.key_attributes.is_empty() || !rm.key_metrics.is_empty()))
+        .map(|m| {
+            m.values()
+                .any(|rm| !rm.key_attributes.is_empty() || !rm.key_metrics.is_empty())
+        })
         .unwrap_or(false);
 
     if !is_enriched {
@@ -594,12 +606,25 @@ async fn cmd_generate(
     let pipeline_config = rag::PipelineConfig {
         add_defaults: !no_defaults,
         use_query_cookbook,
+        explain_selection_process,
     };
 
     // Generate GAQL using MultiStepRAGAgent
-    let result = rag::convert_to_gaql(example_queries, field_cache, &prompt, &llm_config, pipeline_config).await?;
+    let result = rag::convert_to_gaql(
+        example_queries,
+        field_cache,
+        &prompt,
+        &llm_config,
+        pipeline_config,
+    )
+    .await?;
 
     println!("{}", result.query);
+
+    // Print explanation if flag is set
+    if explain_selection_process {
+        rag::print_selection_explanation(&result.pipeline_trace, &prompt);
+    }
 
     // Log validation errors/warnings if any
     if !result.validation.errors.is_empty() {
@@ -618,14 +643,39 @@ async fn cmd_generate(
     // Log pipeline trace if verbose
     if verbose {
         log::debug!("--- Pipeline Trace ---");
-        log::debug!("Phase 1 - Primary resource: {}", result.pipeline_trace.phase1_primary_resource);
-        log::debug!("Phase 1 - Related resources: {:?}", result.pipeline_trace.phase1_related_resources);
-        log::debug!("Phase 1 - Reasoning: {}", result.pipeline_trace.phase1_reasoning);
-        log::debug!("Phase 2 - Candidates: {} (rejected: {})", result.pipeline_trace.phase2_candidate_count, result.pipeline_trace.phase2_rejected_count);
-        log::debug!("Phase 3 - Selected fields: {:?}", result.pipeline_trace.phase3_selected_fields);
-        log::debug!("Phase 3 - Filter fields: {:?}", result.pipeline_trace.phase3_filter_fields);
-        log::debug!("Phase 3 - Order by: {:?}", result.pipeline_trace.phase3_order_by_fields);
-        log::debug!("Phase 4 - WHERE clauses: {:?}", result.pipeline_trace.phase4_where_clauses);
+        log::debug!(
+            "Phase 1 - Primary resource: {}",
+            result.pipeline_trace.phase1_primary_resource
+        );
+        log::debug!(
+            "Phase 1 - Related resources: {:?}",
+            result.pipeline_trace.phase1_related_resources
+        );
+        log::debug!(
+            "Phase 1 - Reasoning: {}",
+            result.pipeline_trace.phase1_reasoning
+        );
+        log::debug!(
+            "Phase 2 - Candidates: {} (rejected: {})",
+            result.pipeline_trace.phase2_candidate_count,
+            result.pipeline_trace.phase2_rejected_count
+        );
+        log::debug!(
+            "Phase 3 - Selected fields: {:?}",
+            result.pipeline_trace.phase3_selected_fields
+        );
+        log::debug!(
+            "Phase 3 - Filter fields: {:?}",
+            result.pipeline_trace.phase3_filter_fields
+        );
+        log::debug!(
+            "Phase 3 - Order by: {:?}",
+            result.pipeline_trace.phase3_order_by_fields
+        );
+        log::debug!(
+            "Phase 4 - WHERE clauses: {:?}",
+            result.pipeline_trace.phase4_where_clauses
+        );
         if let Some(during) = &result.pipeline_trace.phase4_during {
             log::debug!("Phase 4 - DURING: {}", during);
         }
@@ -633,19 +683,22 @@ async fn cmd_generate(
             log::debug!("Phase 4 - LIMIT: {}", limit);
         }
         if !result.pipeline_trace.phase4_implicit_filters.is_empty() {
-            log::debug!("Phase 4 - Implicit filters: {:?}", result.pipeline_trace.phase4_implicit_filters);
+            log::debug!(
+                "Phase 4 - Implicit filters: {:?}",
+                result.pipeline_trace.phase4_implicit_filters
+            );
         }
-        log::debug!("Generation time: {}ms", result.pipeline_trace.generation_time_ms);
+        log::debug!(
+            "Generation time: {}ms",
+            result.pipeline_trace.generation_time_ms
+        );
     }
 
     Ok(())
 }
 
 /// Index embeddings for fast query generation
-async fn cmd_index(
-    queries: Option<String>,
-    metadata: Option<PathBuf>,
-) -> Result<()> {
+async fn cmd_index(queries: Option<String>, metadata: Option<PathBuf>) -> Result<()> {
     validate_llm_env()?;
 
     let llm_config = rag::LlmConfig::from_env();
@@ -658,7 +711,10 @@ async fn cmd_index(
         let queries_path = config_file_path(&queries_file)
             .with_context(|| format!("Could not find queries file: {}", queries_file))?;
         println!("Loading query cookbook from {:?}...", queries_path);
-        get_queries_from_file(&queries_path).await?.into_values().collect()
+        get_queries_from_file(&queries_path)
+            .await?
+            .into_values()
+            .collect()
     } else if let Some(default_path) = config_file_path("query_cookbook.toml") {
         // Try to auto-discover query_cookbook.toml in config directory
         if default_path.exists() {
@@ -686,7 +742,9 @@ async fn cmd_index(
     println!("Loading field metadata from {:?}...", metadata_path);
     let field_cache = FieldMetadataCache::load_from_disk(&metadata_path)
         .await
-        .context("Failed to load field metadata. Run 'mcc-gaql-gen enrich' first or use --metadata.")?;
+        .context(
+            "Failed to load field metadata. Run 'mcc-gaql-gen enrich' first or use --metadata.",
+        )?;
 
     // Check if cache already exists and is valid
     match rag::validate_cache_for_data(&field_cache, &example_queries)? {
@@ -703,7 +761,8 @@ async fn cmd_index(
 
     // Build embeddings only (no RAG pipeline)
     let start = std::time::Instant::now();
-    rag::build_embeddings(example_queries, &field_cache, &llm_config).await
+    rag::build_embeddings(example_queries, &field_cache, &llm_config)
+        .await
         .context("Failed to build embeddings index")?;
 
     println!("\n--- Indexing Complete ---");
@@ -713,14 +772,22 @@ async fn cmd_index(
     let status = vector_store::check_cache_status()?;
     println!("\nCache Status:");
     println!("  Field metadata: valid: {}", status.field_metadata_valid);
-    println!("  Field metadata: updated: {}", vector_store::format_timestamp(status.field_metadata_updated));
+    println!(
+        "  Field metadata: updated: {}",
+        vector_store::format_timestamp(status.field_metadata_updated)
+    );
     println!("  Query cookbook: valid: {}", status.query_cookbook_valid);
-    println!("  Query cookbook: updated: {}", vector_store::format_timestamp(status.query_cookbook_updated));
+    println!(
+        "  Query cookbook: updated: {}",
+        vector_store::format_timestamp(status.query_cookbook_updated)
+    );
 
     if status.is_valid() {
         println!("\nYou can now run 'mcc-gaql-gen generate' for instant GAQL generation.");
     } else {
-        println!("\nWARNING: Some caches may be incomplete. Run this command again if issues persist.");
+        println!(
+            "\nWARNING: Some caches may be incomplete. Run this command again if issues persist."
+        );
     }
 
     Ok(())
@@ -776,7 +843,10 @@ async fn cmd_parse_protos(output: Option<PathBuf>, force: bool) -> Result<()> {
 
     // Check if we should skip (cache exists and not forced)
     if !force && output_path.exists() {
-        println!("Proto docs cache already exists at {:?}. Use --force to rebuild.", output_path);
+        println!(
+            "Proto docs cache already exists at {:?}. Use --force to rebuild.",
+            output_path
+        );
         let cache = proto_docs_cache::ProtoDocsCache::load_from_disk(&output_path)?;
         let stats = cache.stats();
         println!("{}", stats);
@@ -792,8 +862,14 @@ async fn cmd_parse_protos(output: Option<PathBuf>, force: bool) -> Result<()> {
 
     let stats = cache.stats();
     println!("\nProto parsing complete:");
-    println!("  - {} messages with {} fields", stats.message_count, stats.field_count);
-    println!("  - {} enums with {} values", stats.enum_count, stats.enum_value_count);
+    println!(
+        "  - {} messages with {} fields",
+        stats.message_count, stats.field_count
+    );
+    println!(
+        "  - {} enums with {} values",
+        stats.enum_count, stats.enum_value_count
+    );
     println!("\nCache saved to: {:?}", output_path);
 
     Ok(())
@@ -896,4 +972,3 @@ mod tests {
         assert!(filtered.is_empty());
     }
 }
-

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -43,10 +43,6 @@ struct Cli {
     #[arg(short, long)]
     verbose: bool,
 
-    /// Enable trace logging (includes full LLM prompts)
-    #[arg(long)]
-    trace: bool,
-
     #[command(subcommand)]
     command: Commands,
 }
@@ -186,7 +182,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Initialize logging
-    init_logger(cli.verbose, cli.trace);
+    init_logger(cli.verbose);
 
     match cli.command {
         Commands::Scrape {
@@ -816,12 +812,10 @@ fn validate_llm_env() -> Result<()> {
 }
 
 /// Initialize logging based on verbosity and environment variables
-fn init_logger(verbose: bool, trace: bool) {
+fn init_logger(verbose: bool) {
     use flexi_logger::{Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
 
-    let base_level = if trace {
-        "trace".to_string()
-    } else if verbose {
+    let base_level = if verbose {
         "debug".to_string()
     } else {
         env::var("MCC_GAQL_LOG_LEVEL").unwrap_or_else(|_| "warn".to_string())

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -526,13 +526,13 @@ async fn cmd_generate(
         // Explicit --queries flag provided
         let queries_path = config_file_path(&queries_file)
             .with_context(|| format!("Could not find queries file: {}", queries_file))?;
-        println!("Loading query cookbook from {:?}...", queries_path);
+        log::info!("Loading query cookbook from {:?}...", queries_path);
         let map = get_queries_from_file(&queries_path).await?;
         map.into_values().collect()
     } else if let Some(default_path) = config_file_path("query_cookbook.toml") {
         // Try to auto-discover query_cookbook.toml in config directory
         if default_path.exists() {
-            println!("Loading query cookbook from {:?}...", default_path);
+            log::info!("Loading query cookbook from {:?}...", default_path);
             match get_queries_from_file(&default_path).await {
                 Ok(map) => map.into_values().collect(),
                 Err(e) => {
@@ -541,11 +541,11 @@ async fn cmd_generate(
                 }
             }
         } else {
-            println!("No query cookbook found. Using enhanced field metadata only.");
+            log::info!("No query cookbook found. Using enhanced field metadata only.");
             Vec::new()
         }
     } else {
-        println!("No query cookbook specified.");
+        log::info!("No query cookbook specified.");
         Vec::new()
     };
 
@@ -553,7 +553,7 @@ async fn cmd_generate(
     let metadata_path = metadata
         .or_else(|| mcc_gaql_common::paths::field_metadata_enriched_path().ok())
         .context("Could not determine enriched metadata path. Use --metadata to specify it.")?;
-    println!("Loading field metadata from {:?}...", metadata_path);
+    log::info!("Loading field metadata from {:?}...", metadata_path);
     let field_cache = FieldMetadataCache::load_from_disk(&metadata_path)
         .await
         .context("Failed to load field metadata. Run 'mcc-gaql-gen enrich' first or use --metadata.")?;
@@ -566,7 +566,7 @@ async fn cmd_generate(
         .unwrap_or(false);
 
     if !is_enriched {
-        println!("WARNING: Metadata does not appear to be enriched. Key fields may not be available.");
+        log::warn!("Metadata does not appear to be enriched. Key fields may not be available.");
     }
 
     // STRICT CHECK: Validate cache matches current data
@@ -582,7 +582,7 @@ async fn cmd_generate(
     }
 
     // Cache is valid - proceed with generation
-    println!("Cache valid. Generating GAQL for: \"{}\"", prompt);
+    log::info!("Cache valid. Generating GAQL for: \"{}\"", prompt);
 
     // Build pipeline config
     let pipeline_config = rag::PipelineConfig {
@@ -592,43 +592,43 @@ async fn cmd_generate(
     // Generate GAQL using MultiStepRAGAgent
     let result = rag::convert_to_gaql(example_queries, field_cache, &prompt, &llm_config, pipeline_config).await?;
 
-    println!("\nGenerated GAQL:\n{}", result.query);
+    println!("{}", result.query);
 
-    // Print validation errors/warnings if any
+    // Log validation errors/warnings if any
     if !result.validation.errors.is_empty() {
-        println!("\nValidation errors:");
+        log::error!("Validation errors:");
         for err in &result.validation.errors {
-            println!("  - {}", err);
+            log::error!("  - {}", err);
         }
     }
     if !result.validation.warnings.is_empty() {
-        println!("\nValidation warnings:");
+        log::warn!("Validation warnings:");
         for warn in &result.validation.warnings {
-            println!("  - {}", warn);
+            log::warn!("  - {}", warn);
         }
     }
 
-    // Print pipeline trace if verbose
+    // Log pipeline trace if verbose
     if verbose {
-        println!("\n--- Pipeline Trace ---");
-        println!("Phase 1 - Primary resource: {}", result.pipeline_trace.phase1_primary_resource);
-        println!("Phase 1 - Related resources: {:?}", result.pipeline_trace.phase1_related_resources);
-        println!("Phase 1 - Reasoning: {}", result.pipeline_trace.phase1_reasoning);
-        println!("Phase 2 - Candidates: {} (rejected: {})", result.pipeline_trace.phase2_candidate_count, result.pipeline_trace.phase2_rejected_count);
-        println!("Phase 3 - Selected fields: {:?}", result.pipeline_trace.phase3_selected_fields);
-        println!("Phase 3 - Filter fields: {:?}", result.pipeline_trace.phase3_filter_fields);
-        println!("Phase 3 - Order by: {:?}", result.pipeline_trace.phase3_order_by_fields);
-        println!("Phase 4 - WHERE clauses: {:?}", result.pipeline_trace.phase4_where_clauses);
+        log::debug!("--- Pipeline Trace ---");
+        log::debug!("Phase 1 - Primary resource: {}", result.pipeline_trace.phase1_primary_resource);
+        log::debug!("Phase 1 - Related resources: {:?}", result.pipeline_trace.phase1_related_resources);
+        log::debug!("Phase 1 - Reasoning: {}", result.pipeline_trace.phase1_reasoning);
+        log::debug!("Phase 2 - Candidates: {} (rejected: {})", result.pipeline_trace.phase2_candidate_count, result.pipeline_trace.phase2_rejected_count);
+        log::debug!("Phase 3 - Selected fields: {:?}", result.pipeline_trace.phase3_selected_fields);
+        log::debug!("Phase 3 - Filter fields: {:?}", result.pipeline_trace.phase3_filter_fields);
+        log::debug!("Phase 3 - Order by: {:?}", result.pipeline_trace.phase3_order_by_fields);
+        log::debug!("Phase 4 - WHERE clauses: {:?}", result.pipeline_trace.phase4_where_clauses);
         if let Some(during) = &result.pipeline_trace.phase4_during {
-            println!("Phase 4 - DURING: {}", during);
+            log::debug!("Phase 4 - DURING: {}", during);
         }
         if let Some(limit) = result.pipeline_trace.phase4_limit {
-            println!("Phase 4 - LIMIT: {}", limit);
+            log::debug!("Phase 4 - LIMIT: {}", limit);
         }
         if !result.pipeline_trace.phase4_implicit_filters.is_empty() {
-            println!("Phase 4 - Implicit filters: {:?}", result.pipeline_trace.phase4_implicit_filters);
+            log::debug!("Phase 4 - Implicit filters: {:?}", result.pipeline_trace.phase4_implicit_filters);
         }
-        println!("Generation time: {}ms", result.pipeline_trace.generation_time_ms);
+        log::debug!("Generation time: {}ms", result.pipeline_trace.generation_time_ms);
     }
 
     Ok(())

--- a/crates/mcc-gaql-gen/src/model_pool.rs
+++ b/crates/mcc-gaql-gen/src/model_pool.rs
@@ -148,6 +148,11 @@ impl ModelLease {
         self.model_index
     }
 
+    /// Returns the temperature setting from the config.
+    pub fn temperature(&self) -> f32 {
+        self.config.temperature()
+    }
+
     /// Create an LLM agent for this model with the given system prompt.
     pub fn create_agent(
         &self,

--- a/crates/mcc-gaql-gen/src/proto_docs_cache.rs
+++ b/crates/mcc-gaql-gen/src/proto_docs_cache.rs
@@ -4,14 +4,14 @@
 //! on every run. The cache is keyed by googleads-rs version/commit.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use std::fs;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::proto_parser::{ProtoMessageDoc, ProtoEnumDoc};
+use crate::proto_parser::{ProtoEnumDoc, ProtoMessageDoc};
 
 /// Convert snake_case to PascalCase.
 /// e.g., "ad_group" -> "AdGroup", "campaign_budget" -> "CampaignBudget"
@@ -78,7 +78,11 @@ impl ProtoDocsCache {
     }
 
     /// Get field documentation for a specific message and field.
-    pub fn get_field_doc(&self, message_name: &str, field_name: &str) -> Option<&crate::proto_parser::ProtoFieldDoc> {
+    pub fn get_field_doc(
+        &self,
+        message_name: &str,
+        field_name: &str,
+    ) -> Option<&crate::proto_parser::ProtoFieldDoc> {
         self.messages
             .get(message_name)
             .and_then(|msg| msg.fields.iter().find(|f| f.field_name == field_name))
@@ -109,8 +113,8 @@ impl ProtoDocsCache {
     /// This allows the LLM enrichment to use proto documentation instead of web-scraped docs.
     /// Preserves all proto information including field behaviors, types, and enum descriptions.
     pub fn to_scraped_docs(&self) -> crate::scraper::ScrapedDocs {
-        use crate::scraper::{ScrapedDocs, ScrapedFieldDoc};
         use crate::proto_parser::FieldBehavior;
+        use crate::scraper::{ScrapedDocs, ScrapedFieldDoc};
         use std::collections::HashMap;
 
         let mut docs: HashMap<String, ScrapedFieldDoc> = HashMap::new();
@@ -123,27 +127,36 @@ impl ProtoDocsCache {
                 let field_key = format!("{}.{}", gaql_resource, field.field_name);
 
                 // Convert field behaviors to strings
-                let field_behavior: Vec<String> = field.field_behavior.iter().map(|b| {
-                    match b {
+                let field_behavior: Vec<String> = field
+                    .field_behavior
+                    .iter()
+                    .map(|b| match b {
                         FieldBehavior::Immutable => "IMMUTABLE".to_string(),
                         FieldBehavior::OutputOnly => "OUTPUT_ONLY".to_string(),
                         FieldBehavior::Required => "REQUIRED".to_string(),
                         FieldBehavior::Optional => "OPTIONAL".to_string(),
-                    }
-                }).collect();
+                    })
+                    .collect();
 
                 // Get enum values and their descriptions if this is an enum field
                 let (enum_values, enum_value_descriptions) = if field.is_enum {
-                    field.enum_type.as_ref().and_then(|enum_type| {
-                        self.enums.get(enum_type).map(|e| {
-                            let values: Vec<String> = e.values.iter().map(|v| v.name.clone()).collect();
-                            let descriptions: Vec<String> = e.values.iter()
-                                .filter(|v| !v.description.is_empty())
-                                .map(|v| format!("{}: {}", v.name, v.description))
-                                .collect();
-                            (values, descriptions)
+                    field
+                        .enum_type
+                        .as_ref()
+                        .and_then(|enum_type| {
+                            self.enums.get(enum_type).map(|e| {
+                                let values: Vec<String> =
+                                    e.values.iter().map(|v| v.name.clone()).collect();
+                                let descriptions: Vec<String> = e
+                                    .values
+                                    .iter()
+                                    .filter(|v| !v.description.is_empty())
+                                    .map(|v| format!("{}: {}", v.name, v.description))
+                                    .collect();
+                                (values, descriptions)
+                            })
                         })
-                    }).unwrap_or_default()
+                        .unwrap_or_default()
                 } else {
                     (Vec::new(), Vec::new())
                 };
@@ -201,7 +214,8 @@ impl ProtoDocsCache {
     /// Load cache from disk.
     pub fn load_from_disk(path: &PathBuf) -> Result<Self> {
         let content = fs::read_to_string(path).context("Failed to read cache file")?;
-        let cache: ProtoDocsCache = serde_json::from_str(&content).context("Failed to parse cache JSON")?;
+        let cache: ProtoDocsCache =
+            serde_json::from_str(&content).context("Failed to parse cache JSON")?;
 
         Ok(cache)
     }
@@ -306,7 +320,6 @@ pub fn load_or_build_cache(proto_dir: &PathBuf) -> Result<ProtoDocsCache> {
     Ok(cache)
 }
 
-
 /// Merge proto documentation into a FieldMetadataCache.
 /// For each field in the cache, look up the proto documentation and populate description.
 pub fn merge_into_field_metadata_cache(
@@ -343,7 +356,9 @@ pub fn merge_into_field_metadata_cache(
             let message_name = snake_to_pascal_case(resource_name);
 
             if let Some(proto_desc) = proto_cache.get_resource_description(&message_name) {
-                if res_meta.description.is_none() || res_meta.description.as_ref().map_or(true, |d| d.is_empty()) {
+                if res_meta.description.is_none()
+                    || res_meta.description.as_ref().map_or(true, |d| d.is_empty())
+                {
                     res_meta.description = Some(proto_desc.to_string());
                 }
             }
@@ -408,13 +423,28 @@ mod tests {
     #[test]
     fn test_gaql_to_proto() {
         // Test basic resource name conversion
-        assert_eq!(gaql_to_proto("campaign.name"), Some(("Campaign".to_string(), "name".to_string())));
-        assert_eq!(gaql_to_proto("ad_group.status"), Some(("AdGroup".to_string(), "status".to_string())));
-        assert_eq!(gaql_to_proto("ad_group_ad.ad_group"), Some(("AdGroupAd".to_string(), "ad_group".to_string())));
+        assert_eq!(
+            gaql_to_proto("campaign.name"),
+            Some(("Campaign".to_string(), "name".to_string()))
+        );
+        assert_eq!(
+            gaql_to_proto("ad_group.status"),
+            Some(("AdGroup".to_string(), "status".to_string()))
+        );
+        assert_eq!(
+            gaql_to_proto("ad_group_ad.ad_group"),
+            Some(("AdGroupAd".to_string(), "ad_group".to_string()))
+        );
 
         // Test metrics and segments
-        assert_eq!(gaql_to_proto("metrics.clicks"), Some(("Metrics".to_string(), "clicks".to_string())));
-        assert_eq!(gaql_to_proto("segments.device"), Some(("Segments".to_string(), "device".to_string())));
+        assert_eq!(
+            gaql_to_proto("metrics.clicks"),
+            Some(("Metrics".to_string(), "clicks".to_string()))
+        );
+        assert_eq!(
+            gaql_to_proto("segments.device"),
+            Some(("Segments".to_string(), "device".to_string()))
+        );
 
         // Test invalid inputs
         assert_eq!(gaql_to_proto("campaign"), None); // No dot
@@ -426,7 +456,10 @@ mod tests {
         assert_eq!(snake_to_pascal_case("campaign"), "Campaign");
         assert_eq!(snake_to_pascal_case("ad_group"), "AdGroup");
         assert_eq!(snake_to_pascal_case("campaign_budget"), "CampaignBudget");
-        assert_eq!(snake_to_pascal_case("ad_group_criterion"), "AdGroupCriterion");
+        assert_eq!(
+            snake_to_pascal_case("ad_group_criterion"),
+            "AdGroupCriterion"
+        );
         assert_eq!(snake_to_pascal_case(""), "");
     }
 }

--- a/crates/mcc-gaql-gen/src/proto_locator.rs
+++ b/crates/mcc-gaql-gen/src/proto_locator.rs
@@ -3,8 +3,8 @@
 //! This module locates the proto files from the googleads-rs crate, which contain
 //! authoritative field-level documentation for the Google Ads API.
 
-use std::path::PathBuf;
 use anyhow::Result;
+use std::path::PathBuf;
 
 /// Locates the googleads-rs proto directory containing V23 proto files.
 ///
@@ -64,8 +64,7 @@ fn find_in_cargo_cache() -> Option<PathBuf> {
             // Look for subdirectories within the checkout (the commit hash folders)
             if let Ok(subdirs) = std::fs::read_dir(&crate_dir) {
                 for subdir in subdirs.flatten() {
-                    let proto_path = subdir.path()
-                        .join("proto/google/ads/googleads/v23");
+                    let proto_path = subdir.path().join("proto/google/ads/googleads/v23");
 
                     if proto_path.exists() {
                         return Some(proto_path);
@@ -144,7 +143,10 @@ mod tests {
             .collect();
 
         // Per spec: 182 resources, 360 enums
-        assert!(resource_files.len() > 100, "Should have >100 resource protos");
+        assert!(
+            resource_files.len() > 100,
+            "Should have >100 resource protos"
+        );
         assert!(enum_files.len() > 200, "Should have >200 enum protos");
     }
 }

--- a/crates/mcc-gaql-gen/src/proto_parser.rs
+++ b/crates/mcc-gaql-gen/src/proto_parser.rs
@@ -3,11 +3,11 @@
 //! This module parses proto files from googleads-rs to extract documentation
 //! comments for fields, messages, and enums.
 
-use std::collections::HashMap;
-use std::path::Path;
 use anyhow::Result;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
 use walkdir::WalkDir;
 
 /// Field behavior annotations (google.api.field_behavior)
@@ -122,8 +122,9 @@ impl ProtoParser {
             // Match field definitions: type name = number;
             // Captures: type, name, number
             field_pattern: Regex::new(
-                r#"(?m)^\s*((?:\w+\.)*\w+)\s+(\w+)\s*=\s*(\d+)(?:\s*\[([^\]]*)\])?;"#
-            ).unwrap(),
+                r#"(?m)^\s*((?:\w+\.)*\w+)\s+(\w+)\s*=\s*(\d+)(?:\s*\[([^\]]*)\])?;"#,
+            )
+            .unwrap(),
             // Match enum definitions: enum EnumName {
             enum_pattern: Regex::new(r"(?m)^\s*enum\s+(\w+)\s*\{").unwrap(),
             // Match enum values: NAME = number;
@@ -131,8 +132,9 @@ impl ProtoParser {
             enum_value_pattern: Regex::new(r"(?m)^\s*(\w+)\s*=\s*(-?\d+)\s*;").unwrap(),
             // Match field behavior: (google.api.field_behavior) = BEHAVIOR
             field_behavior_pattern: Regex::new(
-                r#"(?m)\(google\.api\.field_behavior\)\s*=\s*(\w+)"#
-            ).unwrap(),
+                r#"(?m)\(google\.api\.field_behavior\)\s*=\s*(\w+)"#,
+            )
+            .unwrap(),
         }
     }
 
@@ -175,7 +177,8 @@ impl ProtoParser {
             let enum_start = caps.get(0).unwrap().start();
 
             // Get the enclosing message name
-            let container_name = self.find_container_message(content, enum_start)
+            let container_name = self
+                .find_container_message(content, enum_start)
                 .unwrap_or_else(|| format!("{}Enum", enum_name));
 
             // Extract enum-level comment
@@ -214,7 +217,12 @@ impl ProtoParser {
     }
 
     /// Extract fields within a message block.
-    fn extract_message_fields(&self, content: &str, msg_start: usize, _message_name: &str) -> Vec<ProtoFieldDoc> {
+    fn extract_message_fields(
+        &self,
+        content: &str,
+        msg_start: usize,
+        _message_name: &str,
+    ) -> Vec<ProtoFieldDoc> {
         // Find message end (matching brace)
         let mut brace_count = 0;
         let mut msg_end = msg_start;
@@ -356,7 +364,12 @@ impl Default for ProtoParser {
 }
 
 /// Parse all proto files in a directory and return combined documentation.
-pub fn parse_all_protos(proto_dir: &Path) -> Result<(HashMap<String, ProtoMessageDoc>, HashMap<String, ProtoEnumDoc>)> {
+pub fn parse_all_protos(
+    proto_dir: &Path,
+) -> Result<(
+    HashMap<String, ProtoMessageDoc>,
+    HashMap<String, ProtoEnumDoc>,
+)> {
     let parser = ProtoParser::new();
     let mut messages = HashMap::new();
     let mut enums = HashMap::new();
@@ -384,10 +397,7 @@ pub fn parse_all_protos(proto_dir: &Path) -> Result<(HashMap<String, ProtoMessag
 
     // Parse enum proto files
     if enums_dir.exists() {
-        for entry in WalkDir::new(&enums_dir)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
+        for entry in WalkDir::new(&enums_dir).into_iter().filter_map(|e| e.ok()) {
             let path = entry.path();
             if path.extension().map_or(false, |ext| ext == "proto") {
                 let content = std::fs::read_to_string(path)?;
@@ -473,7 +483,11 @@ message Campaign {
         assert_eq!(status_field.field_number, 2);
         assert!(status_field.description.contains("status"));
         assert!(status_field.description.contains("ENABLED"));
-        assert!(status_field.field_behavior.contains(&FieldBehavior::OutputOnly));
+        assert!(
+            status_field
+                .field_behavior
+                .contains(&FieldBehavior::OutputOnly)
+        );
     }
 
     #[test]
@@ -486,6 +500,9 @@ message Campaign {
     #[test]
     fn test_proto_to_gaql_field() {
         assert_eq!(proto_to_gaql_field("Campaign", "name"), "campaign.name");
-        assert_eq!(proto_to_gaql_field("AdGroup", "campaign"), "ad_group.campaign");
+        assert_eq!(
+            proto_to_gaql_field("AdGroup", "campaign"),
+            "ad_group.campaign"
+        );
     }
 }

--- a/crates/mcc-gaql-gen/src/r2.rs
+++ b/crates/mcc-gaql-gen/src/r2.rs
@@ -19,14 +19,12 @@ struct R2Config {
 impl R2Config {
     /// Load R2 configuration from environment variables
     fn from_env() -> Result<Self> {
-        let account_id = std::env::var("R2_ACCOUNT_ID")
-            .context("R2_ACCOUNT_ID must be set")?;
-        let bucket = std::env::var("R2_BUCKET")
-            .unwrap_or_else(|_| "mcc-gaql".to_string());
-        let access_key = std::env::var("R2_ACCESS_KEY")
-            .context("R2_ACCESS_KEY must be set for upload")?;
-        let secret_key = std::env::var("R2_SECRET_KEY")
-            .context("R2_SECRET_KEY must be set for upload")?;
+        let account_id = std::env::var("R2_ACCOUNT_ID").context("R2_ACCOUNT_ID must be set")?;
+        let bucket = std::env::var("R2_BUCKET").unwrap_or_else(|_| "mcc-gaql".to_string());
+        let access_key =
+            std::env::var("R2_ACCESS_KEY").context("R2_ACCESS_KEY must be set for upload")?;
+        let secret_key =
+            std::env::var("R2_SECRET_KEY").context("R2_SECRET_KEY must be set for upload")?;
 
         Ok(Self {
             account_id,
@@ -38,10 +36,7 @@ impl R2Config {
 
     /// Returns the S3 endpoint URL for this R2 bucket
     fn endpoint(&self) -> String {
-        format!(
-            "https://{}.r2.cloudflarestorage.com",
-            self.account_id
-        )
+        format!("https://{}.r2.cloudflarestorage.com", self.account_id)
     }
 }
 
@@ -66,11 +61,7 @@ pub async fn download(public_base_url: &str, object_key: &str, dest_path: &Path)
         .with_context(|| format!("GET {} failed", url))?;
 
     if !response.status().is_success() {
-        anyhow::bail!(
-            "Download failed: HTTP {} for {}",
-            response.status(),
-            url
-        );
+        anyhow::bail!("Download failed: HTTP {} for {}", response.status(), url);
     }
 
     let bytes = response
@@ -89,11 +80,7 @@ pub async fn download(public_base_url: &str, object_key: &str, dest_path: &Path)
         .await
         .with_context(|| format!("Failed to write to {:?}", dest_path))?;
 
-    log::info!(
-        "Downloaded {} bytes to {:?}",
-        bytes.len(),
-        dest_path
-    );
+    log::info!("Downloaded {} bytes to {:?}", bytes.len(), dest_path);
     Ok(())
 }
 
@@ -113,14 +100,14 @@ pub async fn upload(object_key: &str, source_path: &Path) -> Result<()> {
         "application/octet-stream"
     };
 
-    let url = format!(
-        "{}/{}/{}",
-        config.endpoint(),
-        config.bucket,
-        object_key
-    );
+    let url = format!("{}/{}/{}", config.endpoint(), config.bucket, object_key);
 
-    log::info!("Uploading {:?} ({} bytes) to {}", source_path, contents.len(), url);
+    log::info!(
+        "Uploading {:?} ({} bytes) to {}",
+        source_path,
+        contents.len(),
+        url
+    );
 
     // Build AWS Signature Version 4 signed request
     let signed_request = sign_s3_request(
@@ -208,11 +195,7 @@ fn sign_s3_request(
     // Canonical request
     let canonical_request = format!(
         "{}\n{}\n\n{}\n{}\n{}",
-        method,
-        canonical_uri,
-        canonical_headers,
-        signed_headers,
-        payload_hash
+        method, canonical_uri, canonical_headers, signed_headers, payload_hash
     );
 
     // String to sign
@@ -237,8 +220,7 @@ fn sign_s3_request(
     let k_service = sign_key(&k_region, "s3");
     let k_signing = sign_key(&k_service, "aws4_request");
 
-    let mut mac =
-        HmacSha256::new_from_slice(&k_signing).expect("HMAC can take key of any size");
+    let mut mac = HmacSha256::new_from_slice(&k_signing).expect("HMAC can take key of any size");
     mac.update(string_to_sign.as_bytes());
     let signature = hex::encode(mac.finalize().into_bytes());
 
@@ -259,7 +241,9 @@ fn sign_s3_request(
         host.parse().context("Invalid host header")?,
     );
     headers.insert(
-        "x-amz-content-sha256".parse::<reqwest::header::HeaderName>().unwrap(),
+        "x-amz-content-sha256"
+            .parse::<reqwest::header::HeaderName>()
+            .unwrap(),
         payload_hash.parse().context("Invalid payload hash")?,
     );
     headers.insert(
@@ -268,7 +252,9 @@ fn sign_s3_request(
     );
     headers.insert(
         reqwest::header::AUTHORIZATION,
-        authorization.parse().context("Invalid authorization header")?,
+        authorization
+            .parse()
+            .context("Invalid authorization header")?,
     );
 
     Ok(SignedRequest { headers })

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -1584,7 +1584,7 @@ Respond ONLY with valid JSON:
         const VALID_OPERATORS: &[&str] = &[
             "=", "!=", "<", ">", "<=", ">=", "IN", "NOT IN", "LIKE", "NOT LIKE",
             "CONTAINS ANY", "CONTAINS ALL", "CONTAINS NONE", "IS NULL", "IS NOT NULL",
-            "BETWEEN", "REGEXP_MATCH", "NOT REGEXP_MATCH",
+            "BETWEEN", "REGEXP_MATCH", "NOT REGEXP_MATCH", "DURING",
         ];
 
         // Add explicit filter fields from LLM
@@ -1596,7 +1596,11 @@ Respond ONLY with valid JSON:
             }
             // Escape single quotes in values
             let escaped_value = ff.value.replace('\'', "\\'");
-            let clause = format!("{} {} '{}'", ff.field_name, op, escaped_value);
+            let clause = match op.as_str() {
+                "IS NULL" | "IS NOT NULL" => format!("{} {}", ff.field_name, op),
+                "DURING" => format!("{} {} {}", ff.field_name, op, escaped_value),  // No quotes for DURING
+                _ => format!("{} {} '{}'", ff.field_name, op, escaped_value),       // Quoted for other operators
+            };
             where_clauses.push(clause);
         }
 
@@ -1642,17 +1646,86 @@ Respond ONLY with valid JSON:
         during: Option<&str>,
         limit: Option<u32>,
     ) -> Result<String, anyhow::Error> {
-        let mut query = String::new();
+        let query = GaqlBuilder::new(primary)
+            .select(field_selection.select_fields.clone())
+            .where_clauses(where_clauses.to_vec())
+            .during(during.map(|s| s.to_string()))
+            .order_by(field_selection.order_by_fields.clone())
+            .limit(limit)
+            .build();
 
-        // SELECT clause - pretty formatted with each field on its own line
-        let mut select_fields: Vec<&str> = field_selection.select_fields.iter().map(|s| s.as_str()).collect();
+        Ok(query)
+    }
+}
 
-        // Add segments.date if temporal but not present
-        let has_date_segment = select_fields.contains(&"segments.date");
-        if during.is_some() && !has_date_segment {
-            select_fields.push("segments.date");
+/// Builder for constructing GAQL queries
+pub struct GaqlBuilder {
+    select_fields: Vec<String>,
+    from_resource: String,
+    where_clauses: Vec<String>,
+    order_by_fields: Vec<(String, String)>,
+    during: Option<String>,
+    limit: Option<u32>,
+}
+
+impl GaqlBuilder {
+    pub fn new(from_resource: &str) -> Self {
+        Self {
+            select_fields: Vec::new(),
+            from_resource: from_resource.to_string(),
+            where_clauses: Vec::new(),
+            order_by_fields: Vec::new(),
+            during: None,
+            limit: None,
+        }
+    }
+
+    pub fn select(mut self, fields: Vec<String>) -> Self {
+        self.select_fields = fields;
+        self
+    }
+
+    pub fn from_resource(mut self, resource: &str) -> Self {
+        self.from_resource = resource.to_string();
+        self
+    }
+
+    pub fn where_clause(mut self, clause: String) -> Self {
+        self.where_clauses.push(clause);
+        self
+    }
+
+    pub fn where_clauses(mut self, clauses: Vec<String>) -> Self {
+        self.where_clauses = clauses;
+        self
+    }
+
+    pub fn during(mut self, period: Option<String>) -> Self {
+        self.during = period;
+        self
+    }
+
+    pub fn order_by(mut self, fields: Vec<(String, String)>) -> Self {
+        self.order_by_fields = fields;
+        self
+    }
+
+    pub fn limit(mut self, limit: Option<u32>) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    pub fn build(self) -> String {
+        // Add segments.date to select if during is set
+        let mut select_fields = self.select_fields;
+        if self.during.is_some() && !select_fields.iter().any(|f| f == "segments.date") {
+            select_fields.push("segments.date".to_string());
         }
 
+        // Build query
+        let mut query = String::new();
+
+        // SELECT clause
         query.push_str("SELECT\n");
         for (i, field) in select_fields.iter().enumerate() {
             query.push_str("  ");
@@ -1664,24 +1737,24 @@ Respond ONLY with valid JSON:
         }
 
         // FROM clause
-        query.push_str(&format!("FROM {}\n", primary));
+        query.push_str(&format!("FROM {}\n", self.from_resource));
 
-        // WHERE clause
-        if !where_clauses.is_empty() {
+        // WHERE clause - combine where_clauses with DURING
+        let mut where_parts = self.where_clauses;
+        if let Some(during) = self.during {
+            where_parts.push(format!("segments.date DURING {}", during));
+        }
+
+        if !where_parts.is_empty() {
             query.push_str("WHERE ");
-            query.push_str(&where_clauses.join(" AND "));
+            query.push_str(&where_parts.join(" AND "));
             query.push('\n');
         }
 
-        // DURING clause
-        if let Some(period) = during {
-            query.push_str(&format!("DURING {}\n", period));
-        }
-
         // ORDER BY clause
-        if !field_selection.order_by_fields.is_empty() {
+        if !self.order_by_fields.is_empty() {
             query.push_str("ORDER BY ");
-            let order_by_parts: Vec<String> = field_selection.order_by_fields
+            let order_by_parts: Vec<String> = self.order_by_fields
                 .iter()
                 .map(|(field, direction)| format!("{} {}", field, direction))
                 .collect();
@@ -1690,11 +1763,11 @@ Respond ONLY with valid JSON:
         }
 
         // LIMIT clause
-        if let Some(n) = limit {
+        if let Some(n) = self.limit {
             query.push_str(&format!("LIMIT {}\n", n));
         }
 
-        Ok(query.trim().to_string())
+        query.trim().to_string()
     }
 }
 
@@ -2046,6 +2119,81 @@ mod tests {
         assert!(result.contains("LIMIT 10"));
         let _ = during;
         let _ = limit;
+    }
+
+    #[test]
+    fn test_during_operator_accepted() {
+        use mcc_gaql_common::field_metadata::FilterField;
+
+        // Test that DURING operator is not rejected
+        let filter = FilterField {
+            field_name: "segments.date".to_string(),
+            operator: "DURING".to_string(),
+            value: "LAST_30_DAYS".to_string(),
+        };
+
+        // The operator should be recognized as valid
+        const VALID_OPERATORS: &[&str] = &[
+            "=", "!=", "<", ">", "<=", ">=", "IN", "NOT IN", "LIKE", "NOT LIKE",
+            "CONTAINS ANY", "CONTAINS ALL", "CONTAINS NONE", "IS NULL", "IS NOT NULL",
+            "BETWEEN", "REGEXP_MATCH", "NOT REGEXP_MATCH", "DURING",
+        ];
+
+        let op = filter.operator.to_uppercase();
+        assert!(VALID_OPERATORS.contains(&op.as_str()), "DURING should be a valid operator");
+
+        // Verify formatting (DURING should not have quotes)
+        let clause = format!("{} {} {}", filter.field_name, op, filter.value);
+        assert_eq!(clause, "segments.date DURING LAST_30_DAYS");
+    }
+
+    #[test]
+    fn test_gaql_builder_basic() {
+        let query = GaqlBuilder::new("campaign")
+            .select(vec!["campaign.name".to_string(), "metrics.clicks".to_string()])
+            .where_clause("campaign.status = 'ENABLED'".to_string())
+            .during(Some("LAST_30_DAYS".to_string()))
+            .order_by(vec![("metrics.clicks".to_string(), "DESC".to_string())])
+            .limit(Some(10))
+            .build();
+
+        assert!(query.contains("SELECT"));
+        assert!(query.contains("campaign.name"));
+        assert!(query.contains("metrics.clicks"));
+        assert!(query.contains("segments.date")); // Auto-added due to DURING
+        assert!(query.contains("FROM campaign"));
+        assert!(query.contains("WHERE campaign.status = 'ENABLED'"));
+        assert!(query.contains("segments.date DURING LAST_30_DAYS"));
+        assert!(query.contains("ORDER BY metrics.clicks DESC"));
+        assert!(query.contains("LIMIT 10"));
+    }
+
+    #[test]
+    fn test_gaql_builder_no_during() {
+        let query = GaqlBuilder::new("ad_group")
+            .select(vec!["ad_group.name".to_string()])
+            .where_clause("ad_group.status = 'ENABLED'".to_string())
+            .build();
+
+        assert!(query.contains("SELECT"));
+        assert!(query.contains("ad_group.name"));
+        assert!(!query.contains("segments.date")); // Not added without DURING
+        assert!(query.contains("FROM ad_group"));
+        assert!(query.contains("WHERE ad_group.status = 'ENABLED'"));
+    }
+
+    #[test]
+    fn test_gaql_builder_during_already_in_select() {
+        // If segments.date is already in select, don't add it twice
+        let query = GaqlBuilder::new("campaign")
+            .select(vec!["campaign.name".to_string(), "segments.date".to_string()])
+            .during(Some("LAST_7_DAYS".to_string()))
+            .build();
+
+        // Count occurrences of segments.date - should be exactly 1 in SELECT
+        let select_part = query.split("FROM").next().unwrap_or("");
+        let count = select_part.matches("segments.date").count();
+        assert_eq!(count, 1, "segments.date should appear exactly once in SELECT");
     }
 
     #[test]

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-use twox_hash::XxHash64;
 use std::vec;
+use twox_hash::XxHash64;
 
 use futures::stream::{self, StreamExt};
 use log::info;
@@ -13,7 +13,7 @@ use rig::{
     completion::Prompt,
     embeddings::{EmbedError, EmbeddingsBuilder, TextEmbedder, embed::Embed},
     providers::openai::{self, completion::CompletionModel},
-    vector_store::{VectorStoreIndex, VectorSearchRequest},
+    vector_store::{VectorSearchRequest, VectorStoreIndex},
 };
 use rig_fastembed::FastembedModel;
 use rig_lancedb::{LanceDbVectorIndex, SearchParams};
@@ -172,7 +172,8 @@ impl LlmConfig {
 }
 
 /// Create embedding client and model
-fn create_embedding_client() -> Result<(rig_fastembed::Client, rig_fastembed::EmbeddingModel), anyhow::Error> {
+fn create_embedding_client()
+-> Result<(rig_fastembed::Client, rig_fastembed::EmbeddingModel), anyhow::Error> {
     // Set HF_HOME to cache fastembed models in the proper location
     let cache_dir = dirs::cache_dir()
         .ok_or_else(|| anyhow::anyhow!("Failed to get cache directory"))?
@@ -188,7 +189,10 @@ fn create_embedding_client() -> Result<(rig_fastembed::Client, rig_fastembed::Em
     // and the process is single-threaded at this point.
     unsafe { std::env::set_var("HF_HOME", &cache_dir) };
 
-    info!("Loading fastembed model: {:?}", FastembedModel::BGESmallENV15);
+    info!(
+        "Loading fastembed model: {:?}",
+        FastembedModel::BGESmallENV15
+    );
 
     let fastembed_client = rig_fastembed::Client::new();
     let embedding_model = fastembed_client.embedding_model(&FastembedModel::BGESmallENV15);
@@ -360,10 +364,8 @@ pub async fn build_embeddings(
     // Build field vector store (this will use cache if valid)
     let field_start = std::time::Instant::now();
     log::info!("Building field metadata embeddings...");
-    let _field_index = build_or_load_field_vector_store(
-        field_cache,
-        resources.embedding_model.clone(),
-    ).await?;
+    let _field_index =
+        build_or_load_field_vector_store(field_cache, resources.embedding_model.clone()).await?;
     log::info!(
         "Field metadata embeddings ready (took {:.2}s)",
         field_start.elapsed().as_secs_f64()
@@ -372,10 +374,8 @@ pub async fn build_embeddings(
     // Build query vector store (this will use cache if valid)
     let query_start = std::time::Instant::now();
     log::info!("Building query cookbook embeddings...");
-    let _query_index = build_or_load_query_vector_store(
-        example_queries,
-        resources.embedding_model,
-    ).await?;
+    let _query_index =
+        build_or_load_query_vector_store(example_queries, resources.embedding_model).await?;
     log::info!(
         "Query cookbook embeddings ready (took {:.2}s)",
         query_start.elapsed().as_secs_f64()
@@ -410,8 +410,7 @@ pub async fn build_or_load_query_vector_store(
                             table,
                             embedding_model,
                             "id",
-                            SearchParams::default()
-                                .distance_type(DistanceType::Cosine)
+                            SearchParams::default().distance_type(DistanceType::Cosine),
                         )
                         .await
                         .map_err(|e| anyhow::anyhow!("Failed to create vector index: {}", e))?;
@@ -495,8 +494,7 @@ pub async fn build_or_load_query_vector_store(
         table,
         embedding_model,
         "id",
-        SearchParams::default()
-            .distance_type(DistanceType::Cosine)
+        SearchParams::default().distance_type(DistanceType::Cosine),
     )
     .await
     .map_err(|e| anyhow::anyhow!("Failed to create vector index: {}", e))?;
@@ -537,52 +535,53 @@ async fn generate_embeddings_parallel<T: Embed + Clone + Send + Sync + 'static>(
         concurrency
     );
 
-    let chunks: Vec<Vec<T>> = documents
-        .chunks(chunk_size)
-        .map(|c| c.to_vec())
-        .collect();
+    let chunks: Vec<Vec<T>> = documents.chunks(chunk_size).map(|c| c.to_vec()).collect();
 
     // Process chunks concurrently and collect results
-    let results: Vec<Result<Vec<(T, Vec<rig::embeddings::Embedding>)>, anyhow::Error>> = stream::iter(chunks.into_iter().enumerate())
-        .map(|(idx, chunk)| {
-            let model = embedding_model.clone();
-            async move {
-                log::debug!("Processing embedding chunk {}/{}", idx + 1, total_chunks);
-                let chunk_start = std::time::Instant::now();
+    let results: Vec<Result<Vec<(T, Vec<rig::embeddings::Embedding>)>, anyhow::Error>> =
+        stream::iter(chunks.into_iter().enumerate())
+            .map(|(idx, chunk)| {
+                let model = embedding_model.clone();
+                async move {
+                    log::debug!("Processing embedding chunk {}/{}", idx + 1, total_chunks);
+                    let chunk_start = std::time::Instant::now();
 
-                // Build embeddings for this chunk
-                let builder = EmbeddingsBuilder::new(model)
-                    .documents(chunk.clone())
-                    .map_err(|e| anyhow::anyhow!("Failed to create embeddings builder: {}", e))?;
+                    // Build embeddings for this chunk
+                    let builder = EmbeddingsBuilder::new(model)
+                        .documents(chunk.clone())
+                        .map_err(|e| {
+                            anyhow::anyhow!("Failed to create embeddings builder: {}", e)
+                        })?;
 
-                let chunk_embeddings = builder
-                    .build()
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to build embeddings: {}", e))?;
+                    let chunk_embeddings = builder
+                        .build()
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to build embeddings: {}", e))?;
 
-                log::debug!(
-                    "Chunk {}/{} completed ({} docs, {:.2}s)",
-                    idx + 1,
-                    total_chunks,
-                    chunk.len(),
-                    chunk_start.elapsed().as_secs_f64()
-                );
+                    log::debug!(
+                        "Chunk {}/{} completed ({} docs, {:.2}s)",
+                        idx + 1,
+                        total_chunks,
+                        chunk.len(),
+                        chunk_start.elapsed().as_secs_f64()
+                    );
 
-                // Convert OneOrMany<Embedding> to Vec<Embedding>
-                let result: Vec<(T, Vec<rig::embeddings::Embedding>)> = chunk_embeddings
-                    .into_iter()
-                    .map(|(doc, one_or_many)| {
-                        let embeddings: Vec<rig::embeddings::Embedding> = one_or_many.into_iter().collect();
-                        (doc, embeddings)
-                    })
-                    .collect();
+                    // Convert OneOrMany<Embedding> to Vec<Embedding>
+                    let result: Vec<(T, Vec<rig::embeddings::Embedding>)> = chunk_embeddings
+                        .into_iter()
+                        .map(|(doc, one_or_many)| {
+                            let embeddings: Vec<rig::embeddings::Embedding> =
+                                one_or_many.into_iter().collect();
+                            (doc, embeddings)
+                        })
+                        .collect();
 
-                Ok(result)
-            }
-        })
-        .buffer_unordered(concurrency)
-        .collect::<Vec<_>>()
-        .await;
+                    Ok(result)
+                }
+            })
+            .buffer_unordered(concurrency)
+            .collect::<Vec<_>>()
+            .await;
 
     // Flatten results and handle errors
     let mut all_embeddings = Vec::with_capacity(total_docs);
@@ -623,30 +622,27 @@ pub async fn build_or_load_field_vector_store(
         log::info!("Field metadata cache valid, loading from LanceDB...");
 
         match lancedb_utils::get_lancedb_connection().await {
-            Ok(db) => {
-                match lancedb_utils::open_table(&db, "field_metadata").await {
-                    Ok(table) => {
-                        let index = LanceDbVectorIndex::new(
-                            table,
-                            embedding_model,
-                            "id",
-                            SearchParams::default()
-                                .distance_type(DistanceType::Cosine)
-                        )
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to create vector index: {}", e))?;
+            Ok(db) => match lancedb_utils::open_table(&db, "field_metadata").await {
+                Ok(table) => {
+                    let index = LanceDbVectorIndex::new(
+                        table,
+                        embedding_model,
+                        "id",
+                        SearchParams::default().distance_type(DistanceType::Cosine),
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to create vector index: {}", e))?;
 
-                        log::info!(
-                            "Successfully loaded field metadata from cache ({:.2}s)",
-                            total_start.elapsed().as_secs_f64()
-                        );
-                        return Ok(index);
-                    }
-                    Err(e) => {
-                        log::warn!("Failed to open cached table: {}, rebuilding...", e);
-                    }
+                    log::info!(
+                        "Successfully loaded field metadata from cache ({:.2}s)",
+                        total_start.elapsed().as_secs_f64()
+                    );
+                    return Ok(index);
                 }
-            }
+                Err(e) => {
+                    log::warn!("Failed to open cached table: {}, rebuilding...", e);
+                }
+            },
             Err(e) => {
                 log::warn!("Failed to connect to LanceDB: {}, rebuilding...", e);
             }
@@ -716,8 +712,7 @@ pub async fn build_or_load_field_vector_store(
         table,
         embedding_model,
         "id",
-        SearchParams::default()
-            .distance_type(DistanceType::Cosine)
+        SearchParams::default().distance_type(DistanceType::Cosine),
     )
     .await
     .map_err(|e| anyhow::anyhow!("Failed to create vector index: {}", e))?;
@@ -927,6 +922,8 @@ pub struct PipelineConfig {
     pub add_defaults: bool,
     /// Whether to use RAG search for query cookbook examples in LLM prompts
     pub use_query_cookbook: bool,
+    /// Whether to print explanation of the LLM selection process
+    pub explain_selection_process: bool,
 }
 
 impl Default for PipelineConfig {
@@ -934,6 +931,7 @@ impl Default for PipelineConfig {
         Self {
             add_defaults: true,
             use_query_cookbook: false,
+            explain_selection_process: false,
         }
     }
 }
@@ -971,16 +969,13 @@ impl MultiStepRAGAgent {
         let resources = init_llm_resources(config)?;
 
         // Build or load field vector store
-        let field_index = build_or_load_field_vector_store(
-            &field_cache,
-            resources.embedding_model.clone(),
-        )
-        .await?;
+        let field_index =
+            build_or_load_field_vector_store(&field_cache, resources.embedding_model.clone())
+                .await?;
 
         // Build or load query vector store
         let query_index =
-            build_or_load_query_vector_store(example_queries, resources.embedding_model)
-                .await?;
+            build_or_load_query_vector_store(example_queries, resources.embedding_model).await?;
 
         Ok(Self {
             llm_config: config.clone(),
@@ -993,7 +988,10 @@ impl MultiStepRAGAgent {
     }
 
     /// Main entry point: generate GAQL query from user prompt
-    pub async fn generate(&self, user_query: &str) -> Result<mcc_gaql_common::field_metadata::GAQLResult, anyhow::Error> {
+    pub async fn generate(
+        &self,
+        user_query: &str,
+    ) -> Result<mcc_gaql_common::field_metadata::GAQLResult, anyhow::Error> {
         let start = std::time::Instant::now();
 
         // Phase 1: Resource selection
@@ -1004,25 +1002,30 @@ impl MultiStepRAGAgent {
         let phase1_time_ms = phase1_start.elapsed().as_millis() as u64;
         log::info!(
             "Phase 1 complete: {} ({}ms)",
-            primary_resource, phase1_time_ms
+            primary_resource,
+            phase1_time_ms
         );
 
         // Phase 2: Field candidate retrieval
         let phase2_start = std::time::Instant::now();
         log::info!("Phase 2: Retrieving field candidates...");
-        let (candidates, candidate_count, rejected_count) =
-            self.retrieve_field_candidates(user_query, &primary_resource, &related_resources)
-                .await?;
+        let (candidates, candidate_count, rejected_count) = self
+            .retrieve_field_candidates(user_query, &primary_resource, &related_resources)
+            .await?;
         let phase2_time_ms = phase2_start.elapsed().as_millis() as u64;
         log::info!(
             "Phase 2 complete: {} candidates ({}ms)",
-            candidates.len(), phase2_time_ms
+            candidates.len(),
+            phase2_time_ms
         );
 
         // Phase 2.5: Pre-scan for filter keywords
         let phase25_start = std::time::Instant::now();
         let filter_enums = self.prescan_filters(user_query, &candidates);
-        log::debug!("Phase 2.5: Pre-scan filters ({}ms)", phase25_start.elapsed().as_millis());
+        log::debug!(
+            "Phase 2.5: Pre-scan filters ({}ms)",
+            phase25_start.elapsed().as_millis()
+        );
 
         // Phase 3: Field selection via LLM
         let phase3_start = std::time::Instant::now();
@@ -1033,17 +1036,18 @@ impl MultiStepRAGAgent {
         let phase3_time_ms = phase3_start.elapsed().as_millis() as u64;
         log::info!(
             "Phase 3 complete: {} fields selected ({}ms)",
-            field_selection.select_fields.len(), phase3_time_ms
+            field_selection.select_fields.len(),
+            phase3_time_ms
         );
 
         // Phase 4: Assemble WHERE, ORDER BY, LIMIT, DURING
         let phase4_start = std::time::Instant::now();
-        let (where_clauses, during, limit, implicit_filters) = self.assemble_criteria(
-            user_query,
-            &field_selection,
-            &primary_resource,
+        let (where_clauses, during, limit, implicit_filters) =
+            self.assemble_criteria(user_query, &field_selection, &primary_resource);
+        log::debug!(
+            "Phase 4: Criteria assembly ({}ms)",
+            phase4_start.elapsed().as_millis()
         );
-        log::debug!("Phase 4: Criteria assembly ({}ms)", phase4_start.elapsed().as_millis());
 
         // Phase 5: Generate final GAQL query
         let phase5_start = std::time::Instant::now();
@@ -1056,25 +1060,40 @@ impl MultiStepRAGAgent {
                 limit,
             )
             .await?;
-        log::debug!("Phase 5: GAQL generation ({}ms)", phase5_start.elapsed().as_millis());
+        log::debug!(
+            "Phase 5: GAQL generation ({}ms)",
+            phase5_start.elapsed().as_millis()
+        );
 
         let generation_time_ms = start.elapsed().as_millis() as u64;
         log::info!(
             "GAQL generation complete: total={}ms (Phase1={}ms, Phase2={}ms, Phase3={}ms)",
-            generation_time_ms, phase1_time_ms, phase2_time_ms, phase3_time_ms
+            generation_time_ms,
+            phase1_time_ms,
+            phase2_time_ms,
+            phase3_time_ms
         );
 
         // Build pipeline trace
+        let phase1_model = self.llm_config.preferred_model().to_string();
+        let phase3_model = self.llm_config.preferred_model().to_string();
         let pipeline_trace = mcc_gaql_common::field_metadata::PipelineTrace {
             phase1_primary_resource: primary_resource.clone(),
             phase1_related_resources: related_resources,
             phase1_dropped_resources: dropped_resources,
             phase1_reasoning: reasoning,
+            phase1_model_used: phase1_model,
+            phase1_timing_ms: phase1_time_ms,
             phase2_candidate_count: candidate_count,
             phase2_rejected_count: rejected_count,
+            phase2_timing_ms: phase2_time_ms,
+            phase25_pre_scan_filters: filter_enums.clone(),
             phase3_selected_fields: field_selection.select_fields.clone(),
             phase3_filter_fields: field_selection.filter_fields.clone(),
             phase3_order_by_fields: field_selection.order_by_fields.clone(),
+            phase3_reasoning: field_selection.reasoning.clone(),
+            phase3_model_used: phase3_model,
+            phase3_timing_ms: phase3_time_ms,
             phase4_where_clauses: where_clauses,
             phase4_during: during,
             phase4_limit: limit,
@@ -1083,11 +1102,15 @@ impl MultiStepRAGAgent {
         };
 
         // Validate the field selection against the primary resource
-        let all_fields: Vec<String> = field_selection.select_fields.iter()
+        let all_fields: Vec<String> = field_selection
+            .select_fields
+            .iter()
             .chain(field_selection.filter_fields.iter().map(|f| &f.field_name))
             .cloned()
             .collect();
-        let validation = self.field_cache.validate_field_selection_for_resource(&all_fields, &primary_resource);
+        let validation = self
+            .field_cache
+            .validate_field_selection_for_resource(&all_fields, &primary_resource);
 
         Ok(mcc_gaql_common::field_metadata::GAQLResult {
             query: result,
@@ -1110,14 +1133,18 @@ impl MultiStepRAGAgent {
         let resource_list: Vec<String> = resources
             .iter()
             .map(|r| {
-                let rm = self.field_cache.resource_metadata.as_ref()
+                let rm = self
+                    .field_cache
+                    .resource_metadata
+                    .as_ref()
                     .and_then(|m| m.get(r));
                 let desc = rm.and_then(|m| m.description.as_deref()).unwrap_or("");
                 format!("- {}: {}", r, desc)
             })
             .collect();
 
-        let system_prompt = r#"You are a Google Ads Query Language (GAQL) expert. Given a user query, determine:
+        let system_prompt =
+            r#"You are a Google Ads Query Language (GAQL) expert. Given a user query, determine:
 1. The primary resource to query FROM (e.g., campaign, ad_group, keyword_view)
 2. Any related resources that might be needed (for JOINs or attributes)
 
@@ -1129,14 +1156,15 @@ Respond ONLY with valid JSON:
   "reasoning": "brief explanation"
 }
 
-Choose from: "#.to_string() + &resource_list.join(", ");
+Choose from: "#
+                .to_string()
+                + &resource_list.join(", ");
 
         let user_prompt = format!("User query: {}", user_query);
 
-        let agent = self.llm_config.create_agent_for_model(
-            self.llm_config.preferred_model(),
-            &system_prompt,
-        )?;
+        let agent = self
+            .llm_config
+            .create_agent_for_model(self.llm_config.preferred_model(), &system_prompt)?;
         log::debug!(
             "Phase 1: Calling LLM (model={}, temp={}) for resource selection...",
             self.llm_config.preferred_model(),
@@ -1173,10 +1201,7 @@ Choose from: "#.to_string() + &resource_list.join(", ");
             })
             .unwrap_or_default();
 
-        let reasoning = parsed["reasoning"]
-            .as_str()
-            .unwrap_or("")
-            .to_string();
+        let reasoning = parsed["reasoning"].as_str().unwrap_or("").to_string();
 
         // Validate related_resources against primary's selectable_with
         let selectable_with = self.field_cache.get_resource_selectable_with(&primary);
@@ -1217,34 +1242,47 @@ Choose from: "#.to_string() + &resource_list.join(", ");
         // =========================================================================
 
         // Get primary resource's key fields from ResourceMetadata
-        if let Some(rm) = self.field_cache.resource_metadata.as_ref().and_then(|m| m.get(primary)) {
+        if let Some(rm) = self
+            .field_cache
+            .resource_metadata
+            .as_ref()
+            .and_then(|m| m.get(primary))
+        {
             // Add key_attributes
             for attr in &rm.key_attributes {
                 if let Some(field) = self.field_cache.fields.get(attr)
-                    && seen.insert(field.name.clone()) {
-                        candidates.push(field.clone());
-                    }
+                    && seen.insert(field.name.clone())
+                {
+                    candidates.push(field.clone());
+                }
             }
             // Add key_metrics
             for metric in &rm.key_metrics {
                 if let Some(field) = self.field_cache.fields.get(metric)
-                    && seen.insert(field.name.clone()) {
-                        candidates.push(field.clone());
-                    }
+                    && seen.insert(field.name.clone())
+                {
+                    candidates.push(field.clone());
+                }
             }
         }
 
         // Add key_attributes from related resources
         for rel in related {
-            if let Some(rm) = self.field_cache.resource_metadata.as_ref().and_then(|m| m.get(rel)) {
+            if let Some(rm) = self
+                .field_cache
+                .resource_metadata
+                .as_ref()
+                .and_then(|m| m.get(rel))
+            {
                 for attr in &rm.key_attributes {
                     if let Some(field) = self.field_cache.fields.get(attr) {
                         // Only add if compatible with primary resource
                         if let Some(resource) = field.get_resource() {
                             if (resource == primary || selectable_with.contains(&resource))
-                                && seen.insert(field.name.clone()) {
-                                    candidates.push(field.clone());
-                                }
+                                && seen.insert(field.name.clone())
+                            {
+                                candidates.push(field.clone());
+                            }
                         }
                     }
                 }
@@ -1302,7 +1340,10 @@ Choose from: "#.to_string() + &resource_list.join(", ");
         let search_start = std::time::Instant::now();
         let (attr_results, metric_results, segment_results) =
             tokio::join!(attr_search, metric_search, segment_search);
-        log::debug!("Phase 2: Vector searches complete in {}ms", search_start.elapsed().as_millis());
+        log::debug!(
+            "Phase 2: Vector searches complete in {}ms",
+            search_start.elapsed().as_millis()
+        );
 
         // Process attribute results: filter to fields starting with "{primary}."
         let prefix = format!("{}.", primary);
@@ -1312,9 +1353,10 @@ Choose from: "#.to_string() + &resource_list.join(", ");
                 // Filter strictly to attributes for the primary resource by name prefix
                 if doc.id.starts_with(&prefix)
                     && let Some(field) = self.field_cache.fields.get(&doc.id)
-                        && seen.insert(field.name.clone()) {
-                            candidates.push(field.clone());
-                        }
+                    && seen.insert(field.name.clone())
+                {
+                    candidates.push(field.clone());
+                }
             }
         }
 
@@ -1323,12 +1365,13 @@ Choose from: "#.to_string() + &resource_list.join(", ");
             for result in results {
                 let doc = &result.2;
                 if (doc.category == "METRIC" || doc.id.starts_with("metrics."))
-                    && let Some(field) = self.field_cache.fields.get(&doc.id) {
-                        // Metrics are compatible if their field name is in the resource's selectable_with
-                        if selectable_with.contains(&field.name) && seen.insert(field.name.clone()) {
-                            candidates.push(field.clone());
-                        }
+                    && let Some(field) = self.field_cache.fields.get(&doc.id)
+                {
+                    // Metrics are compatible if their field name is in the resource's selectable_with
+                    if selectable_with.contains(&field.name) && seen.insert(field.name.clone()) {
+                        candidates.push(field.clone());
                     }
+                }
             }
         }
 
@@ -1337,12 +1380,13 @@ Choose from: "#.to_string() + &resource_list.join(", ");
             for result in results {
                 let doc = &result.2;
                 if (doc.category == "SEGMENT" || doc.id.starts_with("segments."))
-                    && let Some(field) = self.field_cache.fields.get(&doc.id) {
-                        // Segments are compatible if their field name is in the resource's selectable_with
-                        if selectable_with.contains(&field.name) && seen.insert(field.name.clone()) {
-                            candidates.push(field.clone());
-                        }
+                    && let Some(field) = self.field_cache.fields.get(&doc.id)
+                {
+                    // Segments are compatible if their field name is in the resource's selectable_with
+                    if selectable_with.contains(&field.name) && seen.insert(field.name.clone()) {
+                        candidates.push(field.clone());
                     }
+                }
             }
         }
 
@@ -1387,27 +1431,30 @@ Choose from: "#.to_string() + &resource_list.join(", ");
         for (keyword, field_name) in keyword_map {
             if query_lower.contains(keyword) {
                 // Find matching candidate field - use ends_with to match qualified names like "campaign.status"
-                if let Some(field) = candidates.iter().find(|f| f.name.ends_with(&format!(".{}", field_name)))
-                    && !field.enum_values.is_empty() {
-                        // Find enum values that match the keyword
-                        let matching_enums: Vec<String> = field
-                            .enum_values
-                            .iter()
-                            .filter(|e| {
-                                let e_lower = e.to_lowercase();
-                                e_lower.contains(keyword)
-                                    || (keyword == "enabled" && e.as_str() == "ENABLED")
-                                    || (keyword == "paused" && e.as_str() == "PAUSED")
-                                    || (keyword == "active" && e.as_str() == "ENABLED")
-                            })
-                            .cloned()
-                            .collect();
+                if let Some(field) = candidates
+                    .iter()
+                    .find(|f| f.name.ends_with(&format!(".{}", field_name)))
+                    && !field.enum_values.is_empty()
+                {
+                    // Find enum values that match the keyword
+                    let matching_enums: Vec<String> = field
+                        .enum_values
+                        .iter()
+                        .filter(|e| {
+                            let e_lower = e.to_lowercase();
+                            e_lower.contains(keyword)
+                                || (keyword == "enabled" && e.as_str() == "ENABLED")
+                                || (keyword == "paused" && e.as_str() == "PAUSED")
+                                || (keyword == "active" && e.as_str() == "ENABLED")
+                        })
+                        .cloned()
+                        .collect();
 
-                        if !matching_enums.is_empty() {
-                            // Use the actual qualified field name (e.g., "campaign.status")
-                            filter_enums.push((field.name.clone(), matching_enums));
-                        }
+                    if !matching_enums.is_empty() {
+                        // Use the actual qualified field name (e.g., "campaign.status")
+                        filter_enums.push((field.name.clone(), matching_enums));
                     }
+                }
             }
         }
 
@@ -1430,7 +1477,10 @@ Choose from: "#.to_string() + &resource_list.join(", ");
             log::debug!("Phase 3: Retrieving cookbook examples...");
             let cookbook_start = std::time::Instant::now();
             let ex = self.retrieve_cookbook_examples(user_query, 3).await?;
-            log::debug!("Phase 3: Cookbook examples retrieved in {}ms", cookbook_start.elapsed().as_millis());
+            log::debug!(
+                "Phase 3: Cookbook examples retrieved in {}ms",
+                cookbook_start.elapsed().as_millis()
+            );
             ex
         } else {
             log::debug!("Phase 3: Skipping cookbook examples (use_query_cookbook=false)");
@@ -1442,7 +1492,9 @@ Choose from: "#.to_string() + &resource_list.join(", ");
         let mut categories = std::collections::HashMap::new();
 
         for field in candidates {
-            let category = categories.entry(field.category.clone()).or_insert_with(Vec::new);
+            let category = categories
+                .entry(field.category.clone())
+                .or_insert_with(Vec::new);
             category.push(field);
         }
 
@@ -1524,10 +1576,9 @@ Respond ONLY with valid JSON:
             (sys, user)
         };
 
-        let agent = self.llm_config.create_agent_for_model(
-            self.llm_config.preferred_model(),
-            &system_prompt,
-        )?;
+        let agent = self
+            .llm_config
+            .create_agent_for_model(self.llm_config.preferred_model(), &system_prompt)?;
         log::debug!(
             "Phase 3: Calling LLM (model={}, temp={}) for field selection...",
             self.llm_config.preferred_model(),
@@ -1562,9 +1613,17 @@ Respond ONLY with valid JSON:
 
         // Fallback: If all LLM fields fail validation, use key_attributes + key_metrics
         let final_select_fields = if select_fields.is_empty() {
-            log::warn!("No valid select_fields from LLM, falling back to key fields for resource '{}'", primary);
+            log::warn!(
+                "No valid select_fields from LLM, falling back to key fields for resource '{}'",
+                primary
+            );
             let mut fallback = Vec::new();
-            if let Some(rm) = self.field_cache.resource_metadata.as_ref().and_then(|m| m.get(primary)) {
+            if let Some(rm) = self
+                .field_cache
+                .resource_metadata
+                .as_ref()
+                .and_then(|m| m.get(primary))
+            {
                 // Add first 3 key_attributes
                 for attr in rm.key_attributes.iter().take(3) {
                     if self.field_cache.fields.contains_key(attr) {
@@ -1583,19 +1642,32 @@ Respond ONLY with valid JSON:
             select_fields
         };
 
-        let filter_fields: Vec<mcc_gaql_common::field_metadata::FilterField> = parsed["filter_fields"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|f| {
-                        let field = f.get("field")?.as_str()?.to_string();
-                        let operator = f.get("operator").and_then(|v| v.as_str()).unwrap_or("=").to_string();
-                        let value = f.get("value").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        Some(mcc_gaql_common::field_metadata::FilterField { field_name: field, operator, value })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+        let filter_fields: Vec<mcc_gaql_common::field_metadata::FilterField> =
+            parsed["filter_fields"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|f| {
+                            let field = f.get("field")?.as_str()?.to_string();
+                            let operator = f
+                                .get("operator")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("=")
+                                .to_string();
+                            let value = f
+                                .get("value")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            Some(mcc_gaql_common::field_metadata::FilterField {
+                                field_name: field,
+                                operator,
+                                value,
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
 
         let order_by_fields: Vec<(String, String)> = parsed["order_by_fields"]
             .as_array()
@@ -1603,21 +1675,35 @@ Respond ONLY with valid JSON:
                 arr.iter()
                     .filter_map(|f| {
                         let field = f.get("field").and_then(|v| v.as_str())?;
-                        let direction = f.get("direction").and_then(|v| v.as_str()).unwrap_or("DESC");
+                        let direction = f
+                            .get("direction")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("DESC");
                         Some((field.to_string(), direction.to_string()))
                     })
                     .collect()
             })
             .unwrap_or_default();
 
+        // Extract reasoning from LLM response
+        let reasoning = parsed["reasoning"]
+            .as_str()
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+
         Ok(FieldSelectionResult {
             select_fields: final_select_fields,
             filter_fields,
             order_by_fields,
+            reasoning,
         })
     }
 
-    async fn retrieve_cookbook_examples(&self, query: &str, limit: usize) -> Result<String, anyhow::Error> {
+    async fn retrieve_cookbook_examples(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<String, anyhow::Error> {
         let search_request = VectorSearchRequest::builder()
             .query(query)
             .samples(limit as u64)
@@ -1632,7 +1718,10 @@ Respond ONLY with valid JSON:
 
         let mut examples = String::new();
         for result in results {
-            examples.push_str(&format!("- {}\n  GAQL: {}\n", result.2.0.description, result.2.0.query));
+            examples.push_str(&format!(
+                "- {}\n  GAQL: {}\n",
+                result.2.0.description, result.2.0.query
+            ));
         }
 
         Ok(examples)
@@ -1653,24 +1742,44 @@ Respond ONLY with valid JSON:
 
         // Valid GAQL operators
         const VALID_OPERATORS: &[&str] = &[
-            "=", "!=", "<", ">", "<=", ">=", "IN", "NOT IN", "LIKE", "NOT LIKE",
-            "CONTAINS ANY", "CONTAINS ALL", "CONTAINS NONE", "IS NULL", "IS NOT NULL",
-            "BETWEEN", "REGEXP_MATCH", "NOT REGEXP_MATCH", "DURING",
+            "=",
+            "!=",
+            "<",
+            ">",
+            "<=",
+            ">=",
+            "IN",
+            "NOT IN",
+            "LIKE",
+            "NOT LIKE",
+            "CONTAINS ANY",
+            "CONTAINS ALL",
+            "CONTAINS NONE",
+            "IS NULL",
+            "IS NOT NULL",
+            "BETWEEN",
+            "REGEXP_MATCH",
+            "NOT REGEXP_MATCH",
+            "DURING",
         ];
 
         // Add explicit filter fields from LLM
         for ff in &field_selection.filter_fields {
             let op = ff.operator.to_uppercase();
             if !VALID_OPERATORS.contains(&op.as_str()) {
-                log::warn!("Invalid operator '{}' for field '{}', skipping", ff.operator, ff.field_name);
+                log::warn!(
+                    "Invalid operator '{}' for field '{}', skipping",
+                    ff.operator,
+                    ff.field_name
+                );
                 continue;
             }
             // Escape single quotes in values
             let escaped_value = ff.value.replace('\'', "\\'");
             let clause = match op.as_str() {
                 "IS NULL" | "IS NOT NULL" => format!("{} {}", ff.field_name, op),
-                "DURING" => format!("{} {} {}", ff.field_name, op, escaped_value),  // No quotes for DURING
-                _ => format!("{} {} '{}'", ff.field_name, op, escaped_value),       // Quoted for other operators
+                "DURING" => format!("{} {} {}", ff.field_name, op, escaped_value), // No quotes for DURING
+                _ => format!("{} {} '{}'", ff.field_name, op, escaped_value), // Quoted for other operators
             };
             where_clauses.push(clause);
         }
@@ -1825,7 +1934,8 @@ impl GaqlBuilder {
         // ORDER BY clause
         if !self.order_by_fields.is_empty() {
             query.push_str("ORDER BY ");
-            let order_by_parts: Vec<String> = self.order_by_fields
+            let order_by_parts: Vec<String> = self
+                .order_by_fields
                 .iter()
                 .map(|(field, direction)| format!("{} {}", field, direction))
                 .collect();
@@ -1847,6 +1957,7 @@ struct FieldSelectionResult {
     select_fields: Vec<String>,
     filter_fields: Vec<mcc_gaql_common::field_metadata::FilterField>,
     order_by_fields: Vec<(String, String)>, // (field_name, direction)
+    reasoning: String,
 }
 
 /// Public entry point for GAQL generation
@@ -1857,8 +1968,157 @@ pub async fn convert_to_gaql(
     config: &LlmConfig,
     pipeline_config: PipelineConfig,
 ) -> Result<mcc_gaql_common::field_metadata::GAQLResult, anyhow::Error> {
-    let agent = MultiStepRAGAgent::init(example_queries, field_cache, config, pipeline_config).await?;
+    let agent =
+        MultiStepRAGAgent::init(example_queries, field_cache, config, pipeline_config).await?;
     agent.generate(prompt).await
+}
+
+/// Print explanation of the LLM selection process to stdout
+pub fn print_selection_explanation(
+    trace: &mcc_gaql_common::field_metadata::PipelineTrace,
+    user_query: &str,
+) {
+    println!();
+    println!("═══════════════════════════════════════════════════════════════");
+    println!("               RAG SELECTION EXPLANATION");
+    println!("═══════════════════════════════════════════════════════════════");
+    println!();
+    println!("User Query: {}", user_query);
+    println!();
+
+    // Phase 1: Resource Selection
+    println!(
+        "## Phase 1: Resource Selection ({}ms)",
+        trace.phase1_timing_ms
+    );
+    println!();
+    println!("Model: {}", trace.phase1_model_used);
+    println!();
+
+    if !trace.phase1_reasoning.is_empty() {
+        println!("LLM Reasoning:");
+        for line in trace.phase1_reasoning.lines() {
+            println!("  {}", line);
+        }
+        println!();
+    }
+
+    println!(
+        "Selected Primary Resource: {}",
+        trace.phase1_primary_resource
+    );
+    if !trace.phase1_related_resources.is_empty() {
+        println!("Related Resources: {:?}", trace.phase1_related_resources);
+    } else {
+        println!("Related Resources: []");
+    }
+    if !trace.phase1_dropped_resources.is_empty() {
+        println!("Dropped Resources: {:?}", trace.phase1_dropped_resources);
+    }
+    println!();
+
+    // Phase 2: Field Candidate Retrieval
+    println!(
+        "## Phase 2: Field Candidate Retrieval ({}ms)",
+        trace.phase2_timing_ms
+    );
+    println!();
+    println!(
+        "Compatible Candidates: {} fields",
+        trace.phase2_candidate_count
+    );
+    println!(
+        "Filtered Out (incompatible): {} fields",
+        trace.phase2_rejected_count
+    );
+    println!();
+
+    // Phase 2.5: Pre-scan Filters
+    if !trace.phase25_pre_scan_filters.is_empty() {
+        println!("## Phase 2.5: Pre-scan Filters");
+        println!();
+        println!("Detected Keywords:");
+        for (field, values) in &trace.phase25_pre_scan_filters {
+            println!("  - {}: {:?}", field, values);
+        }
+        println!();
+    }
+
+    // Phase 3: Field Selection
+    println!("## Phase 3: Field Selection ({}ms)", trace.phase3_timing_ms);
+    println!();
+    println!("Model: {}", trace.phase3_model_used);
+    println!();
+
+    if !trace.phase3_reasoning.is_empty() {
+        println!("LLM Reasoning:");
+        for line in trace.phase3_reasoning.lines() {
+            println!("  {}", line);
+        }
+        println!();
+    }
+
+    println!("Selected Fields:");
+    for field in &trace.phase3_selected_fields {
+        println!("  - {}", field);
+    }
+    if trace.phase3_selected_fields.is_empty() {
+        println!("  (none)");
+    }
+    println!();
+
+    if !trace.phase3_filter_fields.is_empty() {
+        println!("Filter Fields:");
+        for filter in &trace.phase3_filter_fields {
+            println!(
+                "  - {} {} {}",
+                filter.field_name, filter.operator, filter.value
+            );
+        }
+        println!();
+    }
+
+    if !trace.phase3_order_by_fields.is_empty() {
+        println!("Order By Fields:");
+        for (field, direction) in &trace.phase3_order_by_fields {
+            println!("  - {} ({})", field, direction);
+        }
+        println!();
+    }
+
+    // Phase 4: Criteria Assembly
+    println!("## Phase 4: Criteria Assembly");
+    println!();
+
+    if !trace.phase4_where_clauses.is_empty() {
+        println!("WHERE Clauses:");
+        for clause in &trace.phase4_where_clauses {
+            println!("  - {}", clause);
+        }
+        println!();
+    }
+
+    if let Some(during) = &trace.phase4_during {
+        println!("DURING: {}", during);
+        println!();
+    }
+
+    if let Some(limit) = trace.phase4_limit {
+        println!("LIMIT: {}", limit);
+        println!();
+    }
+
+    if !trace.phase4_implicit_filters.is_empty() {
+        println!("Implicit Filters:");
+        for filter in &trace.phase4_implicit_filters {
+            println!("  - {}", filter);
+        }
+        println!();
+    }
+
+    println!("═══════════════════════════════════════════════════════════════");
+    println!("Total Generation Time: {}ms", trace.generation_time_ms);
+    println!("═══════════════════════════════════════════════════════════════");
 }
 
 /// Helper function for detect_temporal_period - extracted for testing
@@ -1876,7 +2136,8 @@ fn detect_temporal_period_impl(query: &str) -> Option<String> {
         ("yesterday", "YESTERDAY"),
         ("last 14 days", "LAST_14_DAYS"),
         ("last 90 days", "LAST_90_DAYS"),
-    ].to_vec();
+    ]
+    .to_vec();
 
     for (pattern, period) in period_map {
         if query_lower.contains(pattern) {
@@ -1995,7 +2256,10 @@ mod tests {
 
         let hash1 = compute_query_cookbook_hash(&queries);
         let hash2 = compute_query_cookbook_hash(&queries);
-        assert_eq!(hash1, hash2, "Hash should be consistent across repeated calls");
+        assert_eq!(
+            hash1, hash2,
+            "Hash should be consistent across repeated calls"
+        );
     }
 
     #[test]
@@ -2123,7 +2387,11 @@ mod tests {
             metrics_compatible: false,
             resource_name: Some("campaign".to_string()),
             selectable_with: vec![],
-            enum_values: vec!["ENABLED".to_string(), "PAUSED".to_string(), "REMOVED".to_string()],
+            enum_values: vec![
+                "ENABLED".to_string(),
+                "PAUSED".to_string(),
+                "REMOVED".to_string(),
+            ],
             attribute_resources: vec![],
             description: None,
             usage_notes: None,
@@ -2135,15 +2403,22 @@ mod tests {
         let keyword = "enabled";
         let field_name = "status";
 
-        let found = candidates.iter().find(|f| f.name.ends_with(&format!(".{}", field_name)));
+        let found = candidates
+            .iter()
+            .find(|f| f.name.ends_with(&format!(".{}", field_name)));
         assert!(found.is_some(), "Should find campaign.status via ends_with");
 
         let field = found.unwrap();
-        let matching: Vec<&String> = field.enum_values.iter()
+        let matching: Vec<&String> = field
+            .enum_values
+            .iter()
             .filter(|e| e.as_str() == "ENABLED" || e.to_lowercase().contains(keyword))
             .collect();
         assert!(!matching.is_empty(), "Should match ENABLED enum value");
-        assert!(query_lower.contains(keyword), "Query should contain keyword");
+        assert!(
+            query_lower.contains(keyword),
+            "Query should contain keyword"
+        );
     }
 
     #[tokio::test]
@@ -2160,6 +2435,7 @@ mod tests {
                 value: "ENABLED".to_string(),
             }],
             order_by_fields: vec![("metrics.clicks".to_string(), "DESC".to_string())],
+            reasoning: String::new(),
         };
 
         let where_clauses = vec!["campaign.status = 'ENABLED'".to_string()];
@@ -2169,7 +2445,11 @@ mod tests {
         // Manually replicate the generate_gaql assembly logic
         let mut query = String::new();
         // SELECT with segments.date appended (during is Some)
-        let select_fields: Vec<&str> = field_selection.select_fields.iter().map(|s| s.as_str()).collect();
+        let select_fields: Vec<&str> = field_selection
+            .select_fields
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
         query.push_str("SELECT ");
         query.push_str(&select_fields.join(", "));
         query.push_str(", segments.date\n");
@@ -2205,13 +2485,32 @@ mod tests {
 
         // The operator should be recognized as valid
         const VALID_OPERATORS: &[&str] = &[
-            "=", "!=", "<", ">", "<=", ">=", "IN", "NOT IN", "LIKE", "NOT LIKE",
-            "CONTAINS ANY", "CONTAINS ALL", "CONTAINS NONE", "IS NULL", "IS NOT NULL",
-            "BETWEEN", "REGEXP_MATCH", "NOT REGEXP_MATCH", "DURING",
+            "=",
+            "!=",
+            "<",
+            ">",
+            "<=",
+            ">=",
+            "IN",
+            "NOT IN",
+            "LIKE",
+            "NOT LIKE",
+            "CONTAINS ANY",
+            "CONTAINS ALL",
+            "CONTAINS NONE",
+            "IS NULL",
+            "IS NOT NULL",
+            "BETWEEN",
+            "REGEXP_MATCH",
+            "NOT REGEXP_MATCH",
+            "DURING",
         ];
 
         let op = filter.operator.to_uppercase();
-        assert!(VALID_OPERATORS.contains(&op.as_str()), "DURING should be a valid operator");
+        assert!(
+            VALID_OPERATORS.contains(&op.as_str()),
+            "DURING should be a valid operator"
+        );
 
         // Verify formatting (DURING should not have quotes)
         let clause = format!("{} {} {}", filter.field_name, op, filter.value);
@@ -2221,7 +2520,10 @@ mod tests {
     #[test]
     fn test_gaql_builder_basic() {
         let query = GaqlBuilder::new("campaign")
-            .select(vec!["campaign.name".to_string(), "metrics.clicks".to_string()])
+            .select(vec![
+                "campaign.name".to_string(),
+                "metrics.clicks".to_string(),
+            ])
             .where_clause("campaign.status = 'ENABLED'".to_string())
             .during(Some("LAST_30_DAYS".to_string()))
             .order_by(vec![("metrics.clicks".to_string(), "DESC".to_string())])
@@ -2257,14 +2559,20 @@ mod tests {
     fn test_gaql_builder_during_already_in_select() {
         // If segments.date is already in select, don't add it twice
         let query = GaqlBuilder::new("campaign")
-            .select(vec!["campaign.name".to_string(), "segments.date".to_string()])
+            .select(vec![
+                "campaign.name".to_string(),
+                "segments.date".to_string(),
+            ])
             .during(Some("LAST_7_DAYS".to_string()))
             .build();
 
         // Count occurrences of segments.date - should be exactly 1 in SELECT
         let select_part = query.split("FROM").next().unwrap_or("");
         let count = select_part.matches("segments.date").count();
-        assert_eq!(count, 1, "segments.date should appear exactly once in SELECT");
+        assert_eq!(
+            count, 1,
+            "segments.date should appear exactly once in SELECT"
+        );
     }
 
     #[test]

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -128,6 +128,11 @@ impl LlmConfig {
     pub fn model_count(&self) -> usize {
         self.models.len()
     }
+
+    /// Returns the temperature setting.
+    pub fn temperature(&self) -> f32 {
+        self.temperature
+    }
 }
 
 impl LlmConfig {
@@ -213,8 +218,7 @@ fn init_llm_resources(config: &LlmConfig) -> Result<AgentResources, anyhow::Erro
 }
 
 /// Format LLM request for debug logging with human-friendly formatting
-#[allow(dead_code)]
-fn format_llm_request_debug(preamble: &Option<String>, prompt: &str) -> String {
+pub fn format_llm_request_debug(preamble: &Option<String>, prompt: &str) -> String {
     let mut output = String::new();
     output.push('\n');
     output.push_str("═══════════════════════════════════════════════════════════════════\n");
@@ -949,10 +953,14 @@ impl MultiStepRAGAgent {
         pipeline_config: PipelineConfig,
     ) -> Result<Self, anyhow::Error> {
         log::info!(
-            "Initializing MultiStepRAGAgent with LLM: {} via {}",
+            "Initializing MultiStepRAGAgent with LLM: {} (temperature={}) via {}",
             config.preferred_model(),
+            config.temperature,
             config.base_url
         );
+        if config.models.len() > 1 {
+            log::info!("  Additional fallback models: {:?}", &config.models[1..]);
+        }
 
         // Initialize shared LLM resources
         let resources = init_llm_resources(config)?;
@@ -1124,10 +1132,22 @@ Choose from: "#.to_string() + &resource_list.join(", ");
             self.llm_config.preferred_model(),
             &system_prompt,
         )?;
-        log::debug!("Phase 1: Calling LLM for resource selection...");
+        log::debug!(
+            "Phase 1: Calling LLM (model={}, temp={}) for resource selection...",
+            self.llm_config.preferred_model(),
+            self.llm_config.temperature
+        );
+        log::trace!(
+            "{}",
+            format_llm_request_debug(&Some(system_prompt.clone()), &user_prompt)
+        );
         let llm_start = std::time::Instant::now();
         let response = agent.prompt(&user_prompt).await?;
-        log::debug!("Phase 1: LLM responded in {}ms", llm_start.elapsed().as_millis());
+        log::debug!(
+            "Phase 1: LLM (model={}) responded in {}ms",
+            self.llm_config.preferred_model(),
+            llm_start.elapsed().as_millis()
+        );
 
         // Parse JSON response (strip markdown fences first)
         let cleaned_response = strip_markdown_code_blocks(&response);
@@ -1469,10 +1489,22 @@ Respond ONLY with valid JSON:
             self.llm_config.preferred_model(),
             &system_prompt,
         )?;
-        log::debug!("Phase 3: Calling LLM for field selection...");
+        log::debug!(
+            "Phase 3: Calling LLM (model={}, temp={}) for field selection...",
+            self.llm_config.preferred_model(),
+            self.llm_config.temperature
+        );
+        log::trace!(
+            "{}",
+            format_llm_request_debug(&Some(system_prompt.clone()), &user_prompt)
+        );
         let llm_start = std::time::Instant::now();
         let response = agent.prompt(&user_prompt).await?;
-        log::debug!("Phase 3: LLM responded in {}ms", llm_start.elapsed().as_millis());
+        log::debug!(
+            "Phase 3: LLM (model={}) responded in {}ms",
+            self.llm_config.preferred_model(),
+            llm_start.elapsed().as_millis()
+        );
 
         // Parse JSON response (strip markdown fences first)
         let cleaned_response = strip_markdown_code_blocks(&response);

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -925,11 +925,16 @@ impl Embed for FieldDocument {
 pub struct PipelineConfig {
     /// Whether to add implicit default filters (e.g., status = ENABLED)
     pub add_defaults: bool,
+    /// Whether to use RAG search for query cookbook examples in LLM prompts
+    pub use_query_cookbook: bool,
 }
 
 impl Default for PipelineConfig {
     fn default() -> Self {
-        Self { add_defaults: true }
+        Self {
+            add_defaults: true,
+            use_query_cookbook: false,
+        }
     }
 }
 
@@ -1420,11 +1425,17 @@ Choose from: "#.to_string() + &resource_list.join(", ");
         candidates: &[FieldMetadata],
         filter_enums: &[(String, Vec<String>)],
     ) -> Result<FieldSelectionResult, anyhow::Error> {
-        // Retrieve top cookbook examples
-        log::debug!("Phase 3: Retrieving cookbook examples...");
-        let cookbook_start = std::time::Instant::now();
-        let examples = self.retrieve_cookbook_examples(user_query, 3).await?;
-        log::debug!("Phase 3: Cookbook examples retrieved in {}ms", cookbook_start.elapsed().as_millis());
+        // Retrieve top cookbook examples only if enabled
+        let examples = if self.pipeline_config.use_query_cookbook {
+            log::debug!("Phase 3: Retrieving cookbook examples...");
+            let cookbook_start = std::time::Instant::now();
+            let ex = self.retrieve_cookbook_examples(user_query, 3).await?;
+            log::debug!("Phase 3: Cookbook examples retrieved in {}ms", cookbook_start.elapsed().as_millis());
+            ex
+        } else {
+            log::debug!("Phase 3: Skipping cookbook examples (use_query_cookbook=false)");
+            String::new()
+        };
 
         // Build candidate list for LLM
         let mut candidate_text = String::new();
@@ -1459,7 +1470,9 @@ Choose from: "#.to_string() + &resource_list.join(", ");
             }
         }
 
-        let system_prompt = r#"You are a Google Ads Query Language (GAQL) expert. Given:
+        // Build prompt conditionally based on whether cookbook is enabled
+        let (system_prompt, user_prompt) = if self.pipeline_config.use_query_cookbook {
+            let sys = r#"You are a Google Ads Query Language (GAQL) expert. Given:
 1. A user query
 2. Cookbook examples
 3. Available fields categorized by type
@@ -1479,11 +1492,37 @@ Respond ONLY with valid JSON:
 - Add order_by_fields for sorting (use DESC for "top", "best", "worst"; ASC for "first" if ascending)
 - Include segments.date if temporal period is specified
 "#.to_string();
+            let user = format!(
+                "User query: {}\n\nCookbook examples:\n{}\n\nAvailable fields:{}",
+                user_query, examples, candidate_text
+            );
+            (sys, user)
+        } else {
+            let sys = r#"You are a Google Ads Query Language (GAQL) expert. Given:
+1. A user query
+2. Available fields categorized by type
 
-        let user_prompt = format!(
-            "User query: {}\n\nCookbook examples:\n{}\n\nAvailable fields:{}",
-            user_query, examples, candidate_text
-        );
+Select the appropriate fields and build WHERE filters.
+
+Respond ONLY with valid JSON:
+{
+  "select_fields": ["field1", "field2", ...],
+  "filter_fields": [{"field": "field_name", "operator": "=", "value": "value"}],
+  "order_by_fields": [{"field": "field_name", "direction": "DESC"}],
+  "reasoning": "brief explanation"
+}
+
+- Use ONLY fields from the provided list
+- Add filter_fields for any WHERE clauses
+- Add order_by_fields for sorting (use DESC for "top", "best", "worst"; ASC for "first" if ascending)
+- Include segments.date if temporal period is specified
+"#.to_string();
+            let user = format!(
+                "User query: {}\n\nAvailable fields:{}",
+                user_query, candidate_text
+            );
+            (sys, user)
+        };
 
         let agent = self.llm_config.create_agent_for_model(
             self.llm_config.preferred_model(),

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -1605,21 +1605,22 @@ Respond ONLY with valid JSON:
     ) -> Result<String, anyhow::Error> {
         let mut query = String::new();
 
-        // SELECT clause
-        let select_fields: Vec<&str> = field_selection.select_fields.iter().map(|s| s.as_str()).collect();
+        // SELECT clause - pretty formatted with each field on its own line
+        let mut select_fields: Vec<&str> = field_selection.select_fields.iter().map(|s| s.as_str()).collect();
 
         // Add segments.date if temporal but not present
         let has_date_segment = select_fields.contains(&"segments.date");
         if during.is_some() && !has_date_segment {
-            query.push_str("SELECT ");
-            if !select_fields.is_empty() {
-                query.push_str(&select_fields.join(", "));
-                query.push_str(", ");
+            select_fields.push("segments.date");
+        }
+
+        query.push_str("SELECT\n");
+        for (i, field) in select_fields.iter().enumerate() {
+            query.push_str("  ");
+            query.push_str(field);
+            if i < select_fields.len() - 1 {
+                query.push_str(",");
             }
-            query.push_str("segments.date\n");
-        } else {
-            query.push_str("SELECT ");
-            query.push_str(&select_fields.join(", "));
             query.push('\n');
         }
 

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -408,7 +408,6 @@ pub async fn build_or_load_query_vector_store(
                             "id",
                             SearchParams::default()
                                 .distance_type(DistanceType::Cosine)
-                                .column("vector"),
                         )
                         .await
                         .map_err(|e| anyhow::anyhow!("Failed to create vector index: {}", e))?;
@@ -494,7 +493,6 @@ pub async fn build_or_load_query_vector_store(
         "id",
         SearchParams::default()
             .distance_type(DistanceType::Cosine)
-            .column("vector"),
     )
     .await
     .map_err(|e| anyhow::anyhow!("Failed to create vector index: {}", e))?;
@@ -630,7 +628,6 @@ pub async fn build_or_load_field_vector_store(
                             "id",
                             SearchParams::default()
                                 .distance_type(DistanceType::Cosine)
-                                .column("vector"),
                         )
                         .await
                         .map_err(|e| anyhow::anyhow!("Failed to create vector index: {}", e))?;
@@ -717,7 +714,6 @@ pub async fn build_or_load_field_vector_store(
         "id",
         SearchParams::default()
             .distance_type(DistanceType::Cosine)
-            .column("vector"),
     )
     .await
     .map_err(|e| anyhow::anyhow!("Failed to create vector index: {}", e))?;

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -3,6 +3,8 @@ use std::hash::{Hash, Hasher};
 use std::vec;
 use twox_hash::XxHash64;
 
+use chrono::Datelike;
+
 use futures::stream::{self, StreamExt};
 use log::info;
 
@@ -1522,53 +1524,124 @@ Choose from: "#
             }
         }
 
+        // Get today's date for temporal calculations
+        let today = chrono::Local::now().date_naive();
+        let yesterday = today - chrono::Duration::days(1);
+        let last_7_start = today - chrono::Duration::days(7);
+        let last_30_start = today - chrono::Duration::days(30);
+        let last_60_start = today - chrono::Duration::days(60);
+        let last_90_start = today - chrono::Duration::days(90);
+        let _last_365_start = today - chrono::Duration::days(365);
+
+        // Calculate this/previous period start dates
+        let this_month_start = today.with_day(1).unwrap_or(today);
+        let prev_month_end = this_month_start - chrono::Duration::days(1);
+        let prev_month_start = prev_month_end.with_day(1).unwrap_or(prev_month_end);
+
+        // Quarter calculations (months 1,4,7,10 are quarter starts)
+        let month = today.month();
+        let quarter_start_month = ((month - 1) / 3) * 3 + 1;
+        let this_quarter_start = chrono::NaiveDate::from_ymd_opt(today.year(), quarter_start_month, 1)
+            .unwrap_or(today);
+        let prev_quarter_end = this_quarter_start - chrono::Duration::days(1);
+        let prev_quarter_month = ((prev_quarter_end.month() - 1) / 3) * 3 + 1;
+        let prev_quarter_start = chrono::NaiveDate::from_ymd_opt(prev_quarter_end.year(), prev_quarter_month, 1)
+            .unwrap_or(prev_quarter_end);
+
+        // Year calculations
+        let this_year_start = chrono::NaiveDate::from_ymd_opt(today.year(), 1, 1).unwrap_or(today);
+        let prev_year_end = this_year_start - chrono::Duration::days(1);
+        let prev_year_start = chrono::NaiveDate::from_ymd_opt(prev_year_end.year(), 1, 1).unwrap_or(prev_year_end);
+
+        // Week calculations (Monday start)
+        let weekday = today.weekday().num_days_from_monday();
+        let this_week_start = today - chrono::Duration::days(weekday as i64);
+        let prev_week_end = this_week_start - chrono::Duration::days(1);
+        let prev_week_start = prev_week_end - chrono::Duration::days(6);
+
         // Build prompt conditionally based on whether cookbook is enabled
         let (system_prompt, user_prompt) = if self.pipeline_config.use_query_cookbook {
-            let sys = r#"You are a Google Ads Query Language (GAQL) expert. Given:
+            let sys = format!(r#"You are a Google Ads Query Language (GAQL) expert. Given:
 1. A user query
 2. Cookbook examples
 3. Available fields categorized by type
 
+Today's date: {today}
+
 Select the appropriate fields and build WHERE filters.
 
 Respond ONLY with valid JSON:
-{
+{{
   "select_fields": ["field1", "field2", ...],
-  "filter_fields": [{"field": "field_name", "operator": "=", "value": "value"}],
-  "order_by_fields": [{"field": "field_name", "direction": "DESC"}],
+  "filter_fields": [{{"field": "field_name", "operator": "=", "value": "value"}}],
+  "order_by_fields": [{{"field": "field_name", "direction": "DESC"}}],
   "reasoning": "brief explanation"
-}
+}}
 
 - Use ONLY fields from the provided list
 - Add filter_fields for any WHERE clauses
 - Add order_by_fields for sorting (use DESC for "top", "best", "worst"; ASC for "first" if ascending)
 - Include segments.date if temporal period is specified
-"#.to_string();
+- For date ranges, ALWAYS use BETWEEN with explicit ISO dates: segments.date BETWEEN 'YYYY-MM-DD' AND 'YYYY-MM-DD'
+- Examples using today's date ({today}):
+  - "last 90 days" / "past quarter" → BETWEEN '{last_90_start}' AND '{today}'
+  - "last 60 days" → BETWEEN '{last_60_start}' AND '{today}'
+  - "last 30 days" → BETWEEN '{last_30_start}' AND '{today}'
+  - "last 7 days" → BETWEEN '{last_7_start}' AND '{today}'
+  - "yesterday" → BETWEEN '{yesterday}' AND '{yesterday}'
+  - "this year" → BETWEEN '{this_year_start}' AND '{today}'
+  - "this quarter" → BETWEEN '{this_quarter_start}' AND '{today}'
+  - "this month" → BETWEEN '{this_month_start}' AND '{today}'
+  - "this week" → BETWEEN '{this_week_start}' AND '{today}'
+  - "previous year" / "last year" → BETWEEN '{prev_year_start}' AND '{prev_year_end}'
+  - "previous quarter" / "last quarter" → BETWEEN '{prev_quarter_start}' AND '{prev_quarter_end}'
+  - "previous month" / "last month" → BETWEEN '{prev_month_start}' AND '{prev_month_end}'
+  - "previous week" / "last week" → BETWEEN '{prev_week_start}' AND '{prev_week_end}'
+- DO NOT use relative date literals like LAST_7_DAYS, TODAY, YESTERDAY
+"#);
             let user = format!(
                 "User query: {}\n\nCookbook examples:\n{}\n\nAvailable fields:{}",
                 user_query, examples, candidate_text
             );
             (sys, user)
         } else {
-            let sys = r#"You are a Google Ads Query Language (GAQL) expert. Given:
+            let sys = format!(r#"You are a Google Ads Query Language (GAQL) expert. Given:
 1. A user query
 2. Available fields categorized by type
+
+Today's date: {today}
 
 Select the appropriate fields and build WHERE filters.
 
 Respond ONLY with valid JSON:
-{
+{{
   "select_fields": ["field1", "field2", ...],
-  "filter_fields": [{"field": "field_name", "operator": "=", "value": "value"}],
-  "order_by_fields": [{"field": "field_name", "direction": "DESC"}],
+  "filter_fields": [{{"field": "field_name", "operator": "=", "value": "value"}}],
+  "order_by_fields": [{{"field": "field_name", "direction": "DESC"}}],
   "reasoning": "brief explanation"
-}
+}}
 
 - Use ONLY fields from the provided list
 - Add filter_fields for any WHERE clauses
 - Add order_by_fields for sorting (use DESC for "top", "best", "worst"; ASC for "first" if ascending)
 - Include segments.date if temporal period is specified
-"#.to_string();
+- For date ranges, ALWAYS use BETWEEN with explicit ISO dates: segments.date BETWEEN 'YYYY-MM-DD' AND 'YYYY-MM-DD'
+- Examples using today's date ({today}):
+  - "last 90 days" / "past quarter" → BETWEEN '{last_90_start}' AND '{today}'
+  - "last 60 days" → BETWEEN '{last_60_start}' AND '{today}'
+  - "last 30 days" → BETWEEN '{last_30_start}' AND '{today}'
+  - "last 7 days" → BETWEEN '{last_7_start}' AND '{today}'
+  - "yesterday" → BETWEEN '{yesterday}' AND '{yesterday}'
+  - "this year" → BETWEEN '{this_year_start}' AND '{today}'
+  - "this quarter" → BETWEEN '{this_quarter_start}' AND '{today}'
+  - "this month" → BETWEEN '{this_month_start}' AND '{today}'
+  - "this week" → BETWEEN '{this_week_start}' AND '{today}'
+  - "previous year" / "last year" → BETWEEN '{prev_year_start}' AND '{prev_year_end}'
+  - "previous quarter" / "last quarter" → BETWEEN '{prev_quarter_start}' AND '{prev_quarter_end}'
+  - "previous month" / "last month" → BETWEEN '{prev_month_start}' AND '{prev_month_end}'
+  - "previous week" / "last week" → BETWEEN '{prev_week_start}' AND '{prev_week_end}'
+- DO NOT use relative date literals like LAST_7_DAYS, TODAY, YESTERDAY
+"#);
             let user = format!(
                 "User query: {}\n\nAvailable fields:{}",
                 user_query, candidate_text

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -984,30 +984,56 @@ impl MultiStepRAGAgent {
         let start = std::time::Instant::now();
 
         // Phase 1: Resource selection
+        let phase1_start = std::time::Instant::now();
+        log::info!("Phase 1: Resource selection...");
         let (primary_resource, related_resources, dropped_resources, reasoning) =
             self.select_resource(user_query).await?;
+        let phase1_time_ms = phase1_start.elapsed().as_millis() as u64;
+        log::info!(
+            "Phase 1 complete: {} ({}ms)",
+            primary_resource, phase1_time_ms
+        );
 
         // Phase 2: Field candidate retrieval
+        let phase2_start = std::time::Instant::now();
+        log::info!("Phase 2: Retrieving field candidates...");
         let (candidates, candidate_count, rejected_count) =
             self.retrieve_field_candidates(user_query, &primary_resource, &related_resources)
                 .await?;
+        let phase2_time_ms = phase2_start.elapsed().as_millis() as u64;
+        log::info!(
+            "Phase 2 complete: {} candidates ({}ms)",
+            candidates.len(), phase2_time_ms
+        );
 
         // Phase 2.5: Pre-scan for filter keywords
+        let phase25_start = std::time::Instant::now();
         let filter_enums = self.prescan_filters(user_query, &candidates);
+        log::debug!("Phase 2.5: Pre-scan filters ({}ms)", phase25_start.elapsed().as_millis());
 
         // Phase 3: Field selection via LLM
+        let phase3_start = std::time::Instant::now();
+        log::info!("Phase 3: Field selection via LLM...");
         let field_selection = self
             .select_fields(user_query, &primary_resource, &candidates, &filter_enums)
             .await?;
+        let phase3_time_ms = phase3_start.elapsed().as_millis() as u64;
+        log::info!(
+            "Phase 3 complete: {} fields selected ({}ms)",
+            field_selection.select_fields.len(), phase3_time_ms
+        );
 
         // Phase 4: Assemble WHERE, ORDER BY, LIMIT, DURING
+        let phase4_start = std::time::Instant::now();
         let (where_clauses, during, limit, implicit_filters) = self.assemble_criteria(
             user_query,
             &field_selection,
             &primary_resource,
         );
+        log::debug!("Phase 4: Criteria assembly ({}ms)", phase4_start.elapsed().as_millis());
 
         // Phase 5: Generate final GAQL query
+        let phase5_start = std::time::Instant::now();
         let result = self
             .generate_gaql(
                 &primary_resource,
@@ -1017,8 +1043,13 @@ impl MultiStepRAGAgent {
                 limit,
             )
             .await?;
+        log::debug!("Phase 5: GAQL generation ({}ms)", phase5_start.elapsed().as_millis());
 
         let generation_time_ms = start.elapsed().as_millis() as u64;
+        log::info!(
+            "GAQL generation complete: total={}ms (Phase1={}ms, Phase2={}ms, Phase3={}ms)",
+            generation_time_ms, phase1_time_ms, phase2_time_ms, phase3_time_ms
+        );
 
         // Build pipeline trace
         let pipeline_trace = mcc_gaql_common::field_metadata::PipelineTrace {
@@ -1093,7 +1124,10 @@ Choose from: "#.to_string() + &resource_list.join(", ");
             self.llm_config.preferred_model(),
             &system_prompt,
         )?;
+        log::debug!("Phase 1: Calling LLM for resource selection...");
+        let llm_start = std::time::Instant::now();
         let response = agent.prompt(&user_prompt).await?;
+        log::debug!("Phase 1: LLM responded in {}ms", llm_start.elapsed().as_millis());
 
         // Parse JSON response (strip markdown fences first)
         let cleaned_response = strip_markdown_code_blocks(&response);
@@ -1239,8 +1273,11 @@ Choose from: "#.to_string() + &resource_list.join(", ");
         };
 
         // Run all 3 searches in parallel
+        log::debug!("Phase 2: Running 3 parallel vector searches...");
+        let search_start = std::time::Instant::now();
         let (attr_results, metric_results, segment_results) =
             tokio::join!(attr_search, metric_search, segment_search);
+        log::debug!("Phase 2: Vector searches complete in {}ms", search_start.elapsed().as_millis());
 
         // Process attribute results: filter to fields starting with "{primary}."
         let prefix = format!("{}.", primary);
@@ -1364,7 +1401,10 @@ Choose from: "#.to_string() + &resource_list.join(", ");
         filter_enums: &[(String, Vec<String>)],
     ) -> Result<FieldSelectionResult, anyhow::Error> {
         // Retrieve top cookbook examples
+        log::debug!("Phase 3: Retrieving cookbook examples...");
+        let cookbook_start = std::time::Instant::now();
         let examples = self.retrieve_cookbook_examples(user_query, 3).await?;
+        log::debug!("Phase 3: Cookbook examples retrieved in {}ms", cookbook_start.elapsed().as_millis());
 
         // Build candidate list for LLM
         let mut candidate_text = String::new();
@@ -1429,7 +1469,10 @@ Respond ONLY with valid JSON:
             self.llm_config.preferred_model(),
             &system_prompt,
         )?;
+        log::debug!("Phase 3: Calling LLM for field selection...");
+        let llm_start = std::time::Instant::now();
         let response = agent.prompt(&user_prompt).await?;
+        log::debug!("Phase 3: LLM responded in {}ms", llm_start.elapsed().as_millis());
 
         // Parse JSON response (strip markdown fences first)
         let cleaned_response = strip_markdown_code_blocks(&response);

--- a/crates/mcc-gaql-gen/src/vector_store.rs
+++ b/crates/mcc-gaql-gen/src/vector_store.rs
@@ -71,6 +71,26 @@ pub fn clear_cache() -> Result<()> {
     Ok(())
 }
 
+/// Clear only LanceDB tables without removing hash files.
+/// Used by tests to avoid "table already exists" errors while
+/// preserving production cache hashes.
+pub async fn clear_lancedb_tables_only() -> Result<()> {
+    let cache_dir = dirs::cache_dir()
+        .ok_or_else(|| anyhow::anyhow!("Failed to get cache directory"))?
+        .join("mcc-gaql")
+        .join("lancedb");
+
+    if cache_dir.exists() {
+        std::fs::remove_dir_all(&cache_dir)?;
+        println!(
+            "Removed LanceDB cache directory: {}",
+            cache_dir.display()
+        );
+    }
+
+    Ok(())
+}
+
 /// Save hash to file with schema version
 pub fn save_hash(cache_type: &str, hash: u64) -> Result<()> {
     let hash_path = get_hash_path(cache_type)?;

--- a/crates/mcc-gaql-gen/src/vector_store.rs
+++ b/crates/mcc-gaql-gen/src/vector_store.rs
@@ -8,8 +8,8 @@ use rig::embeddings::Embedding;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use mcc_gaql_common::config::QueryEntry;
 use crate::rag::FieldDocument;
+use mcc_gaql_common::config::QueryEntry;
 
 /// Embedding dimension for BGESmallENV15 model
 pub const EMBEDDING_DIM: i32 = 384;
@@ -82,10 +82,7 @@ pub async fn clear_lancedb_tables_only() -> Result<()> {
 
     if cache_dir.exists() {
         std::fs::remove_dir_all(&cache_dir)?;
-        println!(
-            "Removed LanceDB cache directory: {}",
-            cache_dir.display()
-        );
+        println!("Removed LanceDB cache directory: {}", cache_dir.display());
     }
 
     Ok(())
@@ -474,8 +471,8 @@ pub async fn build_or_load_field_vector_store(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mcc_gaql_common::field_metadata::FieldMetadata;
     use crate::rag::FieldDocument;
+    use mcc_gaql_common::field_metadata::FieldMetadata;
 
     #[test]
     fn test_query_cookbook_schema() {

--- a/crates/mcc-gaql-gen/tests/field_vector_store_rag_tests.rs
+++ b/crates/mcc-gaql-gen/tests/field_vector_store_rag_tests.rs
@@ -1,15 +1,21 @@
 
 use mcc_gaql_common::field_metadata::{FieldMetadata, FieldMetadataCache};
-use mcc_gaql_gen::rag::{FieldDocument, FieldDocumentFlat, build_or_load_field_vector_store};
-use mcc_gaql_gen::vector_store::clear_lancedb_tables_only;
+use mcc_gaql_gen::rag::{FieldDocument, FieldDocumentFlat};
+use rig::embeddings::EmbeddingsBuilder;
 use rig::vector_store::{VectorSearchRequest, VectorStoreIndex};
 use rig_fastembed::{Client as FastembedClient, FastembedModel};
-use rig_lancedb::LanceDbVectorIndex;
+use rig_lancedb::{LanceDbVectorIndex, SearchParams};
+use lancedb::DistanceType;
+use arrow_array::{ArrayRef, BooleanArray, FixedSizeListArray, Float64Array, RecordBatch, RecordBatchIterator, StringArray};
+use arrow_schema::{DataType, Field, Schema};
 use std::collections::{HashMap, HashSet};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 #[allow(unused_imports)]
 use dirs;
+
+/// Embedding dimension for BGESmallENV15 model
+const EMBEDDING_DIM: i32 = 384;
 
 /// Shared embedding model to avoid parallel initialization issues
 fn get_shared_embedding_model() -> &'static rig_fastembed::EmbeddingModel {
@@ -215,15 +221,10 @@ fn create_test_field_cache() -> FieldMetadataCache {
     }
 }
 
-/// Helper to create the field vector store for testing with synthetic data
+/// Helper to create the field vector store for testing with synthetic data.
+/// Uses a temp directory to avoid affecting production cache.
 async fn get_test_field_vector_store()
 -> anyhow::Result<LanceDbVectorIndex<rig_fastembed::EmbeddingModel>> {
-    // Clear only LanceDB tables to avoid "table already exists" errors
-    // when running tests concurrently or after interrupted runs.
-    // NOTE: We intentionally do NOT clear hash files to avoid invalidating
-    // the production query cookbook cache.
-    let _ = clear_lancedb_tables_only().await;
-
     // Create synthetic field cache for testing
     let field_cache = create_test_field_cache();
 
@@ -235,10 +236,151 @@ async fn get_test_field_vector_store()
     // Use shared embedding model to avoid parallel initialization issues
     let embedding_model = get_shared_embedding_model().clone();
 
-    // Build or load vector store
-    let vector_store = build_or_load_field_vector_store(&field_cache, embedding_model).await?;
+    // Convert FieldMetadataCache to FieldDocuments
+    let field_docs: Vec<FieldDocument> = field_cache
+        .fields
+        .values()
+        .cloned()
+        .map(FieldDocument::new)
+        .collect();
 
-    Ok(vector_store)
+    // Generate embeddings
+    let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
+        .documents(field_docs.clone())?
+        .build()
+        .await?;
+
+    // Match embeddings to documents by ID
+    let mut embedding_map: HashMap<String, Vec<f64>> = HashMap::new();
+    for (doc_ref, emb) in embeddings.iter() {
+        let embedding_vec: Vec<f64> = emb.iter().flat_map(|e| e.vec.clone()).collect();
+        embedding_map.insert(doc_ref.id.clone(), embedding_vec);
+    }
+
+    // Create documents with embeddings matched by ID
+    let mut docs_with_embeddings: Vec<(FieldDocument, Vec<f64>)> = Vec::new();
+    for doc in field_docs {
+        let vec = embedding_map
+            .get(&doc.id)
+            .cloned()
+            .unwrap_or_else(|| vec![0.0_f64; EMBEDDING_DIM as usize]);
+        docs_with_embeddings.push((doc, vec));
+    }
+
+    // Create temp directory for LanceDB (isolated from production cache)
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_field_rag.lancedb");
+    let db = lancedb::connect(db_path.to_str().unwrap())
+        .execute()
+        .await?;
+
+    println!("Created test LanceDB at: {}", db_path.display());
+
+    // Define schema matching the field metadata structure
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, false),
+        Field::new("category", DataType::Utf8, false),
+        Field::new("data_type", DataType::Utf8, false),
+        Field::new("selectable", DataType::Boolean, false),
+        Field::new("filterable", DataType::Boolean, false),
+        Field::new("sortable", DataType::Boolean, false),
+        Field::new("metrics_compatible", DataType::Boolean, false),
+        Field::new("resource_name", DataType::Utf8, true),
+        Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float64, true)),
+                EMBEDDING_DIM,
+            ),
+            false,
+        ),
+    ]));
+
+    // Convert documents to Arrow arrays
+    let ids: StringArray =
+        StringArray::from_iter_values(docs_with_embeddings.iter().map(|(d, _)| d.id.as_str()));
+    let descriptions: StringArray =
+        StringArray::from_iter_values(docs_with_embeddings.iter().map(|(d, _)| d.description.as_str()));
+    let categories: StringArray =
+        StringArray::from_iter_values(docs_with_embeddings.iter().map(|(d, _)| d.field.category.as_str()));
+    let data_types: StringArray =
+        StringArray::from_iter_values(docs_with_embeddings.iter().map(|(d, _)| d.field.data_type.as_str()));
+    let selectable: BooleanArray = docs_with_embeddings
+        .iter()
+        .map(|(d, _)| Some(d.field.selectable))
+        .collect();
+    let filterable: BooleanArray = docs_with_embeddings
+        .iter()
+        .map(|(d, _)| Some(d.field.filterable))
+        .collect();
+    let sortable: BooleanArray = docs_with_embeddings
+        .iter()
+        .map(|(d, _)| Some(d.field.sortable))
+        .collect();
+    let metrics_compatible: BooleanArray = docs_with_embeddings
+        .iter()
+        .map(|(d, _)| Some(d.field.metrics_compatible))
+        .collect();
+    let resource_names: StringArray = StringArray::from_iter(
+        docs_with_embeddings
+            .iter()
+            .map(|(d, _)| d.field.resource_name.as_deref()),
+    );
+
+    // Convert embeddings to FixedSizeListArray
+    let embedding_values: Vec<f64> = docs_with_embeddings
+        .iter()
+        .flat_map(|(_, vec)| vec.clone())
+        .collect();
+
+    let vectors = FixedSizeListArray::try_new(
+        Arc::new(Field::new("item", DataType::Float64, true)),
+        EMBEDDING_DIM,
+        Arc::new(Float64Array::from(embedding_values)),
+        None,
+    )?;
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(ids) as ArrayRef,
+            Arc::new(descriptions) as ArrayRef,
+            Arc::new(categories) as ArrayRef,
+            Arc::new(data_types) as ArrayRef,
+            Arc::new(selectable) as ArrayRef,
+            Arc::new(filterable) as ArrayRef,
+            Arc::new(sortable) as ArrayRef,
+            Arc::new(metrics_compatible) as ArrayRef,
+            Arc::new(resource_names) as ArrayRef,
+            Arc::new(vectors) as ArrayRef,
+        ],
+    )?;
+
+    let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+
+    // Create LanceDB table
+    let table = db
+        .create_table("field_metadata", Box::new(batches))
+        .execute()
+        .await?;
+
+    // Create vector index
+    let index = LanceDbVectorIndex::new(
+        table,
+        embedding_model,
+        "id",
+        SearchParams::default()
+            .distance_type(DistanceType::Cosine)
+            .column("vector"),
+    )
+    .await?;
+
+    // Keep temp_dir alive by leaking it (tests are short-lived anyway)
+    // This prevents the directory from being deleted before the test completes
+    std::mem::forget(temp_dir);
+
+    Ok(index)
 }
 
 /// Helper to search the vector store with a query and limit

--- a/crates/mcc-gaql-gen/tests/field_vector_store_rag_tests.rs
+++ b/crates/mcc-gaql-gen/tests/field_vector_store_rag_tests.rs
@@ -1,7 +1,7 @@
 
 use mcc_gaql_common::field_metadata::{FieldMetadata, FieldMetadataCache};
 use mcc_gaql_gen::rag::{FieldDocument, FieldDocumentFlat, build_or_load_field_vector_store};
-use mcc_gaql_gen::vector_store::clear_cache;
+use mcc_gaql_gen::vector_store::clear_lancedb_tables_only;
 use rig::vector_store::{VectorSearchRequest, VectorStoreIndex};
 use rig_fastembed::{Client as FastembedClient, FastembedModel};
 use rig_lancedb::LanceDbVectorIndex;
@@ -218,9 +218,11 @@ fn create_test_field_cache() -> FieldMetadataCache {
 /// Helper to create the field vector store for testing with synthetic data
 async fn get_test_field_vector_store()
 -> anyhow::Result<LanceDbVectorIndex<rig_fastembed::EmbeddingModel>> {
-    // Clear cache before creating to avoid "table already exists" errors
-    // when running tests concurrently or after interrupted runs
-    let _ = clear_cache();
+    // Clear only LanceDB tables to avoid "table already exists" errors
+    // when running tests concurrently or after interrupted runs.
+    // NOTE: We intentionally do NOT clear hash files to avoid invalidating
+    // the production query cookbook cache.
+    let _ = clear_lancedb_tables_only().await;
 
     // Create synthetic field cache for testing
     let field_cache = create_test_field_cache();

--- a/crates/mcc-gaql-gen/tests/field_vector_store_rag_tests.rs
+++ b/crates/mcc-gaql-gen/tests/field_vector_store_rag_tests.rs
@@ -1,13 +1,15 @@
-
+use arrow_array::{
+    ArrayRef, BooleanArray, FixedSizeListArray, Float64Array, RecordBatch, RecordBatchIterator,
+    StringArray,
+};
+use arrow_schema::{DataType, Field, Schema};
+use lancedb::DistanceType;
 use mcc_gaql_common::field_metadata::{FieldMetadata, FieldMetadataCache};
 use mcc_gaql_gen::rag::{FieldDocument, FieldDocumentFlat};
 use rig::embeddings::EmbeddingsBuilder;
 use rig::vector_store::{VectorSearchRequest, VectorStoreIndex};
 use rig_fastembed::{Client as FastembedClient, FastembedModel};
 use rig_lancedb::{LanceDbVectorIndex, SearchParams};
-use lancedb::DistanceType;
-use arrow_array::{ArrayRef, BooleanArray, FixedSizeListArray, Float64Array, RecordBatch, RecordBatchIterator, StringArray};
-use arrow_schema::{DataType, Field, Schema};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
@@ -300,12 +302,21 @@ async fn get_test_field_vector_store()
     // Convert documents to Arrow arrays
     let ids: StringArray =
         StringArray::from_iter_values(docs_with_embeddings.iter().map(|(d, _)| d.id.as_str()));
-    let descriptions: StringArray =
-        StringArray::from_iter_values(docs_with_embeddings.iter().map(|(d, _)| d.description.as_str()));
-    let categories: StringArray =
-        StringArray::from_iter_values(docs_with_embeddings.iter().map(|(d, _)| d.field.category.as_str()));
-    let data_types: StringArray =
-        StringArray::from_iter_values(docs_with_embeddings.iter().map(|(d, _)| d.field.data_type.as_str()));
+    let descriptions: StringArray = StringArray::from_iter_values(
+        docs_with_embeddings
+            .iter()
+            .map(|(d, _)| d.description.as_str()),
+    );
+    let categories: StringArray = StringArray::from_iter_values(
+        docs_with_embeddings
+            .iter()
+            .map(|(d, _)| d.field.category.as_str()),
+    );
+    let data_types: StringArray = StringArray::from_iter_values(
+        docs_with_embeddings
+            .iter()
+            .map(|(d, _)| d.field.data_type.as_str()),
+    );
     let selectable: BooleanArray = docs_with_embeddings
         .iter()
         .map(|(d, _)| Some(d.field.selectable))

--- a/crates/mcc-gaql-gen/tests/minimal_rag_test.rs
+++ b/crates/mcc-gaql-gen/tests/minimal_rag_test.rs
@@ -1,5 +1,3 @@
-
-
 /// Minimal RAG test to verify the rig + rig-lancedb stack works correctly
 /// Uses the actual field metadata structure and queries from the production system
 use anyhow::Result;

--- a/crates/mcc-gaql/build.rs
+++ b/crates/mcc-gaql/build.rs
@@ -65,9 +65,7 @@ fn get_git_hash() -> String {
     };
 
     // Check for uncommitted changes
-    let dirty_output = Command::new("git")
-        .args(["status", "--porcelain"])
-        .output();
+    let dirty_output = Command::new("git").args(["status", "--porcelain"]).output();
 
     let is_dirty = match dirty_output {
         Ok(output) => !output.stdout.is_empty(),

--- a/crates/mcc-gaql/src/args.rs
+++ b/crates/mcc-gaql/src/args.rs
@@ -5,9 +5,8 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 
 /// Version string including git hash (computed lazily at first use)
-static VERSION: LazyLock<String> = LazyLock::new(|| {
-    format!("{} ({})", env!("CARGO_PKG_VERSION"), env!("GIT_HASH"))
-});
+static VERSION: LazyLock<String> =
+    LazyLock::new(|| format!("{} ({})", env!("CARGO_PKG_VERSION"), env!("GIT_HASH")));
 
 /// Output format for query results
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/mcc-gaql/src/config.rs
+++ b/crates/mcc-gaql/src/config.rs
@@ -5,7 +5,9 @@ use figment::{
 use serde::{Deserialize, Serialize};
 use std::fs;
 
-use mcc_gaql_common::config::{MyConfig, TOML_CONFIG_FILENAME, ENV_VAR_PREFIX, validate_and_normalize_customer_id};
+use mcc_gaql_common::config::{
+    ENV_VAR_PREFIX, MyConfig, TOML_CONFIG_FILENAME, validate_and_normalize_customer_id,
+};
 use mcc_gaql_common::paths::config_file_path;
 
 const CRATE_NAME: &str = "mcc-gaql";
@@ -479,8 +481,14 @@ mod tests {
         assert_eq!(config.customer_id, deserialized.customer_id);
         assert_eq!(config.format, deserialized.format);
         assert_eq!(config.keep_going, deserialized.keep_going);
-        assert_eq!(config.token_cache_filename, deserialized.token_cache_filename);
-        assert_eq!(config.customerids_filename, deserialized.customerids_filename);
+        assert_eq!(
+            config.token_cache_filename,
+            deserialized.token_cache_filename
+        );
+        assert_eq!(
+            config.customerids_filename,
+            deserialized.customerids_filename
+        );
         assert_eq!(config.queries_filename, deserialized.queries_filename);
     }
 
@@ -510,9 +518,15 @@ mod tests {
         assert_eq!(config.customer_id, deserialized.customer_id);
         assert_eq!(config.format, deserialized.format);
         assert_eq!(config.keep_going, deserialized.keep_going);
-        assert_eq!(config.token_cache_filename, deserialized.token_cache_filename);
+        assert_eq!(
+            config.token_cache_filename,
+            deserialized.token_cache_filename
+        );
         assert_eq!(config.queries_filename, deserialized.queries_filename);
-        assert_eq!(config.customerids_filename, deserialized.customerids_filename);
+        assert_eq!(
+            config.customerids_filename,
+            deserialized.customerids_filename
+        );
     }
 
     #[test]

--- a/crates/mcc-gaql/src/field_metadata.rs
+++ b/crates/mcc-gaql/src/field_metadata.rs
@@ -223,4 +223,3 @@ fn build_resource_metadata_from_fields(
 
     resource_metadata
 }
-

--- a/crates/mcc-gaql/src/main.rs
+++ b/crates/mcc-gaql/src/main.rs
@@ -65,25 +65,24 @@ async fn main() -> Result<()> {
         log::debug!("Handle Field Metadata command. Resolved configuration: {resolved_config:?}");
 
         // Obtain API access for field metadata operations that require it
-        let api_context = if args.refresh_field_cache
-            || args.export_field_metadata
-            || args.show_fields.is_some()
-        {
-            resolved_config.validate_for_operation(&args)?;
-            Some(
-                googleads::get_api_access(&googleads::ApiAccessConfig {
-                    mcc_customer_id: resolved_config.mcc_customer_id.clone(),
-                    token_cache_filename: resolved_config.token_cache_filename.clone(),
-                    user_email: resolved_config.user_email.clone(),
-                    dev_token: resolved_config.dev_token.clone(),
-                    use_remote_auth: resolved_config.remote_auth,
-                })
-                .await
-                .context("Authentication required for field metadata operations")?,
-            )
-        } else {
-            None
-        };
+        let api_context =
+            if args.refresh_field_cache || args.export_field_metadata || args.show_fields.is_some()
+            {
+                resolved_config.validate_for_operation(&args)?;
+                Some(
+                    googleads::get_api_access(&googleads::ApiAccessConfig {
+                        mcc_customer_id: resolved_config.mcc_customer_id.clone(),
+                        token_cache_filename: resolved_config.token_cache_filename.clone(),
+                        user_email: resolved_config.user_email.clone(),
+                        dev_token: resolved_config.dev_token.clone(),
+                        use_remote_auth: resolved_config.remote_auth,
+                    })
+                    .await
+                    .context("Authentication required for field metadata operations")?,
+                )
+            } else {
+                None
+            };
 
         let cache_path = std::path::PathBuf::from(&resolved_config.field_metadata_cache);
 
@@ -251,9 +250,8 @@ async fn main() -> Result<()> {
             );
 
             // remove cached token to force re-auth and try again
-            let token_cache_path =
-                config_file_path(&resolved_config.token_cache_filename)
-                    .context("Failed to determine token cache file path")?;
+            let token_cache_path = config_file_path(&resolved_config.token_cache_filename)
+                .context("Failed to determine token cache file path")?;
 
             fs::remove_file(&token_cache_path).context(format!(
                 "Failed to remove invalid token cache at: {}",
@@ -315,34 +313,43 @@ async fn main() -> Result<()> {
         googleads::fields_query(api_context, query).await;
     } else if args.gaql_query.is_some() {
         // figure out which customerids to query for
-        let customer_ids: Option<Vec<String>> =
-            if customer_id.is_some() & args.all_linked_child_accounts {
-                let cid = customer_id.expect("Valid customer_id required.");
-                log::debug!("Querying child accounts under MCC: {}", &cid);
-                (googleads::get_child_account_ids(api_context.clone(), cid.to_string()).await).ok()
-            } else if customer_id.is_some() & !args.all_linked_child_accounts {
-                let cid = customer_id.expect("Valid customer_id required.");
-                log::debug!("Querying account: {cid}");
-                Some(vec![cid.to_string()])
-            } else if customer_id.is_none() & args.all_linked_child_accounts {
-                let cid = mcc_customer_id.to_string();
-                log::debug!("Querying all linked child accounts under MCC: {}", &cid);
-                (googleads::get_child_account_ids(api_context.clone(), cid).await).ok()
-            } else if customer_id.is_none() & !args.all_linked_child_accounts {
-                if let Some(customerids_filename) = resolved_config.customerids_filename.as_deref() {
-                    let customerids_path =
-                        config_file_path(customerids_filename).unwrap();
-                    log::debug!("Querying accounts listed in file: {}", customerids_path.display());
+        let customer_ids: Option<Vec<String>> = if customer_id.is_some()
+            & args.all_linked_child_accounts
+        {
+            let cid = customer_id.expect("Valid customer_id required.");
+            log::debug!("Querying child accounts under MCC: {}", &cid);
+            (googleads::get_child_account_ids(api_context.clone(), cid.to_string()).await).ok()
+        } else if customer_id.is_some() & !args.all_linked_child_accounts {
+            let cid = customer_id.expect("Valid customer_id required.");
+            log::debug!("Querying account: {cid}");
+            Some(vec![cid.to_string()])
+        } else if customer_id.is_none() & args.all_linked_child_accounts {
+            let cid = mcc_customer_id.to_string();
+            log::debug!("Querying all linked child accounts under MCC: {}", &cid);
+            (googleads::get_child_account_ids(api_context.clone(), cid).await).ok()
+        } else if customer_id.is_none() & !args.all_linked_child_accounts {
+            if let Some(customerids_filename) = resolved_config.customerids_filename.as_deref() {
+                let customerids_path = config_file_path(customerids_filename).unwrap();
+                log::debug!(
+                    "Querying accounts listed in file: {}",
+                    customerids_path.display()
+                );
 
-                    (mcc_gaql_common::config::get_child_account_ids_from_file(customerids_path.as_path()).await).ok()
-                } else {
-                    log::warn!("No customerids file specified. Use --customer-id or --all-linked-child-accounts");
-                    None
-                }
+                (mcc_gaql_common::config::get_child_account_ids_from_file(
+                    customerids_path.as_path(),
+                )
+                .await)
+                    .ok()
             } else {
-                log::warn!("Not supposed to get here.");
+                log::warn!(
+                    "No customerids file specified. Use --customer-id or --all-linked-child-accounts"
+                );
                 None
-            };
+            }
+        } else {
+            log::warn!("Not supposed to get here.");
+            None
+        };
 
         // apply query to all customer_ids
         if let Some(customer_ids_vector) = customer_ids {
@@ -477,18 +484,16 @@ async fn gaql_query_async(
     let groupby_start = Instant::now();
     while let Some(result) = groupby_handles.next().await {
         match result {
-            Ok(future) => {
-                match future.await {
-                    Ok(df) => {
-                        if !df.is_empty() {
-                            dataframes.push(df);
-                        }
-                    }
-                    Err(e) => {
-                        log::error!("GROUPBY Error: {e}");
+            Ok(future) => match future.await {
+                Ok(df) => {
+                    if !df.is_empty() {
+                        dataframes.push(df);
                     }
                 }
-            }
+                Err(e) => {
+                    log::error!("GROUPBY Error: {e}");
+                }
+            },
             Err(e) => {
                 log::error!("Thread JOIN Error: {e}");
             }
@@ -737,17 +742,15 @@ fn output_dataframe(
     let resolved_format = resolve_output_format(format, &outfile)?;
 
     match outfile {
-        Some(path) => {
-            match resolved_format {
-                OutputFormat::Csv => write_csv(df, &path)?,
-                OutputFormat::Json => write_json(df, &path)?,
-                OutputFormat::Table => {
-                    log::warn!("Writing table format to file, consider using csv or json");
-                    let mut f = File::create(path)?;
-                    write!(f, "{}", df)?;
-                }
+        Some(path) => match resolved_format {
+            OutputFormat::Csv => write_csv(df, &path)?,
+            OutputFormat::Json => write_json(df, &path)?,
+            OutputFormat::Table => {
+                log::warn!("Writing table format to file, consider using csv or json");
+                let mut f = File::create(path)?;
+                write!(f, "{}", df)?;
             }
-        }
+        },
         None => match resolved_format {
             OutputFormat::Csv => write_csv_to_stdout(df)?,
             OutputFormat::Json => write_json_to_stdout(df)?,

--- a/crates/mcc-gaql/tests/config_tests.rs
+++ b/crates/mcc-gaql/tests/config_tests.rs
@@ -140,8 +140,7 @@ fn test_validate_succeeds_with_existing_token_cache() {
     use std::io::Write;
 
     // Get the proper token cache path using config_file_path
-    let token_cache_path =
-        config_file_path("tokencache_test_temp.json").expect("token cache path");
+    let token_cache_path = config_file_path("tokencache_test_temp.json").expect("token cache path");
 
     // Ensure config directory exists
     if let Some(parent) = token_cache_path.parent() {

--- a/specs/explain_selection_process.md
+++ b/specs/explain_selection_process.md
@@ -1,0 +1,354 @@
+# Design Spec: --explain-selection-process Flag
+
+## Overview
+Add a new `--explain-selection-process` flag to `mcc-gaql-gen` that provides transparency into the LLM-assisted RAG selection process. The explanation is printed to stdout (not logs) in human-readable format.
+
+## User Goals
+- Understand why the LLM chose a particular primary resource
+- See what candidate fields were available to the LLM for field selection
+- Understand the LLM's reasoning for selecting specific fields
+- Debug cases where unexpected fields were selected (or expected fields were missed)
+
+## Current RAG Flow (for context)
+
+```
+Phase 1: Resource Selection
+  - Input: user query + master list of all resources
+  - LLM selects: primary_resource, related_resources
+  - LLM returns: confidence, reasoning
+
+Phase 2: Field Candidate Retrieval
+  - Input: user query + primary resource
+  - Retrieves: key fields + vector search results (attrs, metrics, segments)
+  - Output: candidate list (can be 60+ fields)
+
+Phase 2.5: Pre-scan Filters
+  - Scans user query for filter keywords
+  - Extracts enum values for WHERE clause suggestions
+
+Phase 3: Field Selection
+  - Input: user query + candidate fields (capped at 15/category for LLM prompt)
+  - LLM selects: select_fields, filter_fields, order_by_fields
+  - LLM returns: reasoning
+```
+
+## Design Decisions
+
+### 1. Output Target: stdout
+- Printed directly to stdout, independent of logging system
+- Not affected by `MCC_GAQL_LOG_LEVEL`
+- Appears alongside normal query output
+
+### 2. Output Format: Human-Readable Text
+```
+═══════════════════════════════════════════════════════════════
+               RAG SELECTION EXPLANATION
+═══════════════════════════════════════════════════════════════
+
+## Phase 1: Resource Selection
+
+User Query: "show me top campaigns by clicks last month"
+
+LLM Reasoning:
+  The user is asking for campaign-level performance data, specifically
+  ranked by clicks. "campaign" is the appropriate primary resource.
+
+Selected Primary Resource: campaign
+Related Resources: []
+
+## Phase 3: Field Selection
+
+Candidate Fields Available to LLM (87 total):
+
+### ATTRIBUTE (23 fields)
+  - campaign.id: ID of the campaign [filterable]
+  - campaign.name: Name of the campaign [filterable]
+  - campaign.status: Status [filterable] (valid: ENABLED, PAUSED)
+  ... (21 more)
+
+### METRIC (45 fields)
+  - metrics.clicks: Number of clicks [sortable]
+  - metrics.cost_micros: Cost in micros [sortable]
+  - metrics.impressions: Number of impressions
+  ... (42 more)
+
+### SEGMENT (19 fields)
+  - segments.date: Date [filterable] [sortable]
+  - segments.device: Device type
+  ... (17 more)
+
+Pre-scanned Filter Hints:
+  - campaign.status: ENABLED (from keyword "active")
+
+LLM Reasoning:
+  Selected campaign.name and metrics.clicks for the core query. Added
+  segments.date because user specified "last month". Added
+  metrics.impressions for context.
+
+Selected Fields:
+  - campaign.name
+  - metrics.clicks
+  - metrics.impressions
+  - segments.date
+
+═══════════════════════════════════════════════════════════════
+```
+
+### 3. Candidate Fields: Show All Retrieved
+- Display the full set from Phase 2 retrieval (not just the 15/category subset)
+- Include field properties: filterable, sortable, enum values
+- Group by category (ATTRIBUTE, METRIC, SEGMENT)
+
+### 4. Flag Behavior
+- Independent flag: `--explain-selection-process`
+- Works regardless of log level
+- Can be combined with other flags
+- Does not affect normal query generation flow
+
+## Implementation Details
+
+### Data to Capture
+
+#### Phase 1: Resource Selection
+| Data | Source | Notes |
+|------|--------|-------|
+| User query | Input param | Already available |
+| LLM reasoning | LLM response | Currently parsed but not stored |
+| Primary resource | LLM response | Currently returned |
+| Related resources | LLM response | Currently returned, filtered |
+
+#### Phase 3: Field Selection
+| Data | Source | Notes |
+|------|--------|-------|
+| All candidate fields | Phase 2 result | Need to pass to Phase 3 or store |
+| Pre-scanned filters | Phase 2.5 result | Already available |
+| LLM reasoning | LLM response | Currently parsed but not stored |
+| Selected fields | LLM response | Currently returned |
+
+### Changes Required
+
+1. **Add CLI flag** (`main.rs`)
+   - Add `--explain-selection-process: bool` to CLI args
+   - Pass to `RagPipelineConfig`
+
+2. **Extend config** (`rag.rs`)
+   - Add `explain_selection_process: bool` to `RagPipelineConfig`
+
+3. **Capture LLM reasoning** (`rag.rs`)
+   - In `select_resource()`: capture and return `reasoning` field
+   - In `select_fields()`: capture and return `reasoning` field
+
+4. **Store candidate fields** (`rag.rs`)
+   - Return full candidate list from `retrieve_field_candidates()`
+   - Pass through to `select_fields()` for explanation output
+
+5. **Create explanation printer** (`rag.rs` or new module)
+   - Function to format and print the explanation to stdout
+   - Called at the end of `generate_query()` if flag is set
+
+### Type Changes
+
+```rust
+// Current
+struct FieldSelectionResult {
+    select_fields: Vec<String>,
+    filter_fields: Vec<FilterField>,
+    order_by_fields: Vec<(String, String)>,
+}
+
+// New - add reasoning and timing
+struct FieldSelectionResult {
+    select_fields: Vec<String>,
+    filter_fields: Vec<FilterField>,
+    order_by_fields: Vec<(String, String)>,
+    reasoning: String,
+    timing_ms: u64,
+    model_used: String,
+    fallback_chain: Vec<String>, // empty if no fallback
+}
+
+// Current resource selection returns tuple
+// Change to structured type
+struct ResourceSelectionResult {
+    primary_resource: String,
+    related_resources: Vec<String>,
+    dropped_resources: Vec<String>,
+    reasoning: String,
+    timing_ms: u64,
+    model_used: String,
+    fallback_chain: Vec<String>,
+}
+
+// New type for field candidate with score
+struct FieldCandidate {
+    field: FieldMetadata,
+    search_score: f32,
+    was_filtered: bool,
+    filter_reason: Option<String>, // e.g., "incompatible with primary"
+}
+
+// New type for Phase 2 result
+struct FieldRetrievalResult {
+    candidates: Vec<FieldCandidate>,
+    compatible_count: usize,
+    filtered_count: usize,
+    timing_ms: u64,
+}
+```
+
+### Output Module (Optional)
+Consider extracting explanation formatting to a new module:
+
+```rust
+// explain.rs
+pub struct SelectionExplanation {
+    pub user_query: String,
+    pub resource_selection: ResourceSelectionExplanation,
+    pub field_selection: FieldSelectionExplanation,
+}
+
+pub struct ResourceSelectionExplanation {
+    pub reasoning: String,
+    pub primary: String,
+    pub related: Vec<String>,
+}
+
+pub struct FieldSelectionExplanation {
+    pub all_candidates: Vec<FieldMetadata>,
+    pub pre_scan_filters: Vec<(String, Vec<String>)>,
+    pub llm_reasoning: String,
+    pub selected_fields: Vec<String>,
+}
+
+impl SelectionExplanation {
+    pub fn print(&self) {
+        // Format and print to stdout
+    }
+}
+```
+
+## Design Decisions Summary
+
+| Question | Decision |
+|----------|----------|
+| Timing information | **Include** - Show duration for each phase |
+| Vector search scores | **Include** - Show similarity scores for candidates |
+| Rejected fields | **Include** - Show fields filtered out due to incompatibility |
+| Cookbook influence | **Include** - Show cookbook examples when flag enabled |
+| Fallback chain | **Include** - Show which models were tried |
+
+## Updated Output Format
+
+```
+═══════════════════════════════════════════════════════════════
+               RAG SELECTION EXPLANATION
+═══════════════════════════════════════════════════════════════
+
+User Query: "show me top campaigns by clicks last month"
+
+## Phase 1: Resource Selection (145ms)
+
+Model: gpt-4o
+
+LLM Reasoning:
+  The user is asking for campaign-level performance data, specifically
+  ranked by clicks. "campaign" is the appropriate primary resource.
+
+Selected Primary Resource: campaign
+Related Resources: []
+
+## Phase 2: Field Candidate Retrieval (89ms)
+
+Vector Search Results:
+
+### Retrieved Attributes (30 results)
+  - campaign.id [score: 0.92]
+  - campaign.name [score: 0.88]
+  - campaign.status [score: 0.85]
+  - ad_group.id [score: 0.82] → FILTERED (incompatible with primary)
+  ...
+
+### Retrieved Metrics (30 results)
+  - metrics.clicks [score: 0.95]
+  - metrics.cost_micros [score: 0.91]
+  ...
+
+### Retrieved Segments (15 results)
+  - segments.date [score: 0.89]
+  ...
+
+Compatible Candidates Passed to Phase 3: 87 fields
+Filtered Out (incompatible): 12 fields
+
+## Phase 2.5: Pre-scan Filters
+
+Detected Keywords:
+  - "active" → campaign.status: [ENABLED]
+  - "last month" → segments.date (temporal range)
+
+## Phase 3: Field Selection (203ms)
+
+Model: gpt-4o (fallback from: o3-mini - timeout after 30s)
+
+Cookbook Examples Consulted (3):
+  - "Top campaigns by clicks"
+    GAQL: SELECT campaign.name, metrics.clicks FROM campaign ...
+  - "Campaign performance by date"
+    GAQL: SELECT campaign.name, segments.date, metrics.clicks ...
+  - "Active campaigns only"
+    GAQL: SELECT campaign.name FROM campaign WHERE campaign.status = 'ENABLED'
+
+Candidate Fields Available to LLM (87 total):
+
+### ATTRIBUTE (23 fields)
+  - campaign.id: ID of the campaign [filterable]
+  - campaign.name: Name of the campaign [filterable]
+  - campaign.status: Status [filterable] (valid: ENABLED, PAUSED)
+  ...
+
+### METRIC (45 fields)
+  - metrics.clicks: Number of clicks [sortable]
+  - metrics.cost_micros: Cost in micros [sortable]
+  ...
+
+### SEGMENT (19 fields)
+  - segments.date: Date [filterable] [sortable]
+  ...
+
+LLM Reasoning:
+  Selected campaign.name and metrics.clicks for the core query. Added
+  segments.date because user specified "last month". Added
+  metrics.impressions for context. Applied filter for active campaigns
+  based on pre-scan hint.
+
+Selected Fields:
+  - campaign.name
+  - metrics.clicks
+  - metrics.impressions
+  - segments.date
+
+═══════════════════════════════════════════════════════════════
+```
+
+## Additional Data to Capture
+
+Based on design decisions, the following additional data must be captured:
+
+| Data | Phase | Source |
+|------|-------|--------|
+| Phase timing | All | `std::time::Instant` |
+| Vector search scores | Phase 2 | Search results (result.1) |
+| Filtered/rejected fields | Phase 2 | Fields that fail compatibility check |
+| Cookbook examples | Phase 3 | `retrieve_cookbook_examples()` |
+| Model used | Phase 1, 3 | LLM config / fallback tracking |
+| Fallback chain | Phase 1, 3 | Track when fallback models are invoked |
+
+## Acceptance Criteria
+
+- [ ] `--explain-selection-process` flag is available in CLI
+- [ ] Flag prints explanation to stdout (not logs)
+- [ ] Resource selection phase shows: user query, LLM reasoning, selected resource
+- [ ] Field selection phase shows: all candidate fields (grouped by category), pre-scanned filters, LLM reasoning, selected fields
+- [ ] Output is human-readable with clear section headers
+- [ ] Normal query generation continues to work unchanged
+- [ ] Flag has no effect on log files or structured output (JSON)

--- a/specs/plan__timing_instrumentation_for_rag_process_kimi.md
+++ b/specs/plan__timing_instrumentation_for_rag_process_kimi.md
@@ -1,0 +1,167 @@
+# Plan: Add Trace and Timing Info to `generate` Command
+
+## Context
+
+The `generate` command takes over a minute to generate GAQL queries with no visibility into what it's doing. From the logs provided, there's a ~1.5 minute gap between:
+- Line 585: `Cache valid. Generating GAQL for: "..."`
+- Line 1551: `Invalid operator 'DURING' for field 'segments.date', skipping`
+
+The user needs visibility into where time is being spent during generation.
+
+## Current State Analysis
+
+Looking at the code flow:
+
+1. **main.rs:585-593**: `cmd_generate` calls `rag::convert_to_gaql()` - **NO timing**
+2. **rag.rs:1666-1675**: `convert_to_gaql()` creates agent and calls `generate()`
+3. **rag.rs:943-980**: `MultiStepRAGAgent::init()` - missing timing for:
+   - `init_llm_resources()` (line 958) - creates LLM and embedding clients
+   - Connection to LanceDB is slow
+4. **rag.rs:983-1021**: `MultiStepRAGAgent::generate()` - has total timing but **NO per-phase timing**
+
+The 5 phases in `generate()`:
+- Phase 1: Resource selection (line 988)
+- Phase 2: Field candidate retrieval (line 991)
+- Phase 2.5: Pre-scan for filter keywords (line 996)
+- Phase 3: Field selection via LLM (line 999) - **this is likely slow (LLM call)**
+- Phase 4: Assemble criteria (line 1004)
+- Phase 5: Generate final GAQL (line 1011) - **this is likely slow (LLM call)**
+
+## Implementation Plan
+
+### 1. Add timing wrapper in `cmd_generate` (main.rs:585-593)
+
+Add timing around the `convert_to_gaql` call and log total time at INFO level:
+
+```rust
+// Around line 585-593
+log::info!("Cache valid. Generating GAQL for: \"{}\"", prompt);
+
+let generate_start = std::time::Instant::now();
+let result = rag::convert_to_gaql(...).await?;
+log::info!(
+    "GAQL generation completed in {:.2}s",
+    generate_start.elapsed().as_secs_f64()
+);
+```
+
+### 2. Add timing to `MultiStepRAGAgent::init` (rag.rs:943-980)
+
+Add timing around initialization steps:
+
+```rust
+// At start of init (line 951)
+let init_start = std::time::Instant::now();
+
+// After init_llm_resources (line 958)
+let llm_resources_start = std::time::Instant::now();
+let resources = init_llm_resources(config)?;
+log::info!(
+    "LLM resources initialized in {:.2}s",
+    llm_resources_start.elapsed().as_secs_f64()
+);
+
+// After field vector store (line 965)
+log::info!(
+    "Field vector store ready in {:.2}s",
+    init_start.elapsed().as_secs_f64()
+);
+
+// After query vector store (line 970)
+log::info!(
+    "Query vector store ready in {:.2}s",
+    init_start.elapsed().as_secs_f64()
+);
+
+// At end (line 980)
+log::info!(
+    "MultiStepRAGAgent initialized in {:.2}s total",
+    init_start.elapsed().as_secs_f64()
+);
+```
+
+### 3. Add per-phase timing in `MultiStepRAGAgent::generate` (rag.rs:983-1021)
+
+Add timing for each phase:
+
+```rust
+// Phase 1
+let phase1_start = std::time::Instant::now();
+let (primary_resource, related_resources, dropped_resources, reasoning) =
+    self.select_resource(user_query).await?;
+log::info!("Phase 1 (resource selection) completed in {:.2}s", phase1_start.elapsed().as_secs_f64());
+
+// Phase 2
+let phase2_start = std::time::Instant::now();
+let (candidates, candidate_count, rejected_count) = ...;
+log::info!("Phase 2 (field retrieval) completed in {:.2}s", phase2_start.elapsed().as_secs_f64());
+
+// Phase 2.5
+let phase2_5_start = std::time::Instant::now();
+let filter_enums = self.prescan_filters(user_query, &candidates);
+log::info!("Phase 2.5 (filter prescan) completed in {:.2}s", phase2_5_start.elapsed().as_secs_f64());
+
+// Phase 3
+let phase3_start = std::time::Instant::now();
+let field_selection = self.select_fields(...).await?;
+log::info!("Phase 3 (field selection) completed in {:.2}s", phase3_start.elapsed().as_secs_f64());
+
+// Phase 4
+let phase4_start = std::time::Instant::now();
+let (where_clauses, during, limit, implicit_filters) = ...;
+log::info!("Phase 4 (criteria assembly) completed in {:.2}s", phase4_start.elapsed().as_secs_f64());
+
+// Phase 5
+let phase5_start = std::time::Instant::now();
+let result = self.generate_gaql(...).await?;
+log::info!("Phase 5 (GAQL generation) completed in {:.2}s", phase5_start.elapsed().as_secs_f64());
+```
+
+### 4. Add timing to `init_llm_resources` (rag.rs:204)
+
+Add timing for embedding client creation:
+
+```rust
+fn init_llm_resources(config: &LlmConfig) -> Result<AgentResources, anyhow::Error> {
+    let llm_start = std::time::Instant::now();
+    let llm_client = config.create_llm_client()?;
+    log::debug!("LLM client created in {:.2}s", llm_start.elapsed().as_secs_f64());
+
+    let embed_start = std::time::Instant::now();
+    let (embed_client, embedding_model) = create_embedding_client()?;
+    log::info!("Embedding client created in {:.2}s", embed_start.elapsed().as_secs_f64());
+
+    Ok(...)
+}
+```
+
+## Files to Modify
+
+1. **crates/mcc-gaql-gen/src/main.rs**
+   - Lines 585-593: Add timing around `convert_to_gaql` call
+
+2. **crates/mcc-gaql-gen/src/rag.rs**
+   - Lines 943-980: Add timing to `MultiStepRAGAgent::init`
+   - Lines 983-1021: Add per-phase timing to `MultiStepRAGAgent::generate`
+   - Lines 204-213: Add timing to `init_llm_resources`
+
+## Verification
+
+After changes, running `mcc-gaql-gen generate "show me audiences with the highest CPA for past quarter"` should show:
+
+```
+[TIME] Cache valid. Generating GAQL for: "..."
+[TIME] LLM resources initialized in X.XXs
+[TIME] Field vector store ready in X.XXs
+[TIME] Query vector store ready in X.XXs
+[TIME] MultiStepRAGAgent initialized in X.XXs total
+[TIME] Phase 1 (resource selection) completed in X.XXs
+[TIME] Phase 2 (field retrieval) completed in X.XXs
+[TIME] Phase 2.5 (filter prescan) completed in X.XXs
+[TIME] Phase 3 (field selection) completed in X.XXs
+[TIME] Phase 4 (criteria assembly) completed in X.XXs
+[TIME] Phase 5 (GAQL generation) completed in X.XXs
+[TIME] GAQL generation completed in X.XXs total
+```
+
+This will make it clear where time is being spent.

--- a/specs/plan__timing_instrumentation_for_rag_process_opus45.md
+++ b/specs/plan__timing_instrumentation_for_rag_process_opus45.md
@@ -1,0 +1,141 @@
+# Plan: Add Timing Instrumentation to GAQL Generate Command
+
+## Context
+
+The `generate` command in `mcc-gaql-gen` takes over a minute to complete, with no visibility into which phase is consuming time. Based on logs, there's a ~105 second gap between cache loading and the first warning, with no intermediate logging.
+
+The pipeline has 5 phases with 2 LLM calls and 4 vector searches. Without timing info, it's impossible to know if slowness is due to:
+- LLM latency (API calls)
+- Vector search performance
+- Embedding generation
+- Data processing
+
+## Implementation Plan
+
+### Files to Modify
+
+**Primary:** `crates/mcc-gaql-gen/src/rag.rs`
+
+### Changes
+
+#### 1. Add Phase-Level Timing in `generate()` (lines 983-1053)
+
+Add timing around each phase call with clear, parseable log output:
+
+```rust
+// Phase 1
+let phase1_start = std::time::Instant::now();
+log::info!("Phase 1: Resource selection...");
+let (primary_resource, ...) = self.select_resource(user_query).await?;
+log::info!("Phase 1 complete: {} ({}ms)", primary_resource, phase1_start.elapsed().as_millis());
+
+// Phase 2
+let phase2_start = std::time::Instant::now();
+log::info!("Phase 2: Retrieving field candidates...");
+let (candidates, ...) = self.retrieve_field_candidates(...).await?;
+log::info!("Phase 2 complete: {} candidates ({}ms)", candidates.len(), phase2_start.elapsed().as_millis());
+
+// Phase 2.5
+let phase25_start = std::time::Instant::now();
+let filter_enums = self.prescan_filters(...);
+log::debug!("Phase 2.5: Pre-scan filters ({}ms)", phase25_start.elapsed().as_millis());
+
+// Phase 3
+let phase3_start = std::time::Instant::now();
+log::info!("Phase 3: Field selection via LLM...");
+let field_selection = self.select_fields(...).await?;
+log::info!("Phase 3 complete: {} fields selected ({}ms)", field_selection.select_fields.len(), phase3_start.elapsed().as_millis());
+
+// Phase 4
+let phase4_start = std::time::Instant::now();
+let (where_clauses, ...) = self.assemble_criteria(...);
+log::debug!("Phase 4: Criteria assembly ({}ms)", phase4_start.elapsed().as_millis());
+
+// Phase 5
+let phase5_start = std::time::Instant::now();
+let result = self.generate_gaql(...).await?;
+log::debug!("Phase 5: GAQL generation ({}ms)", phase5_start.elapsed().as_millis());
+```
+
+#### 2. Add LLM Call Timing in `select_resource()` (line 1096)
+
+```rust
+log::debug!("Phase 1: Calling LLM for resource selection...");
+let llm_start = std::time::Instant::now();
+let response = agent.prompt(&user_prompt).await?;
+log::debug!("Phase 1: LLM responded in {}ms", llm_start.elapsed().as_millis());
+```
+
+#### 3. Add Vector Search Timing in `retrieve_field_candidates()` (lines 1241-1243)
+
+```rust
+log::debug!("Phase 2: Running 3 parallel vector searches...");
+let search_start = std::time::Instant::now();
+let (attr_results, metric_results, segment_results) =
+    tokio::join!(attr_search, metric_search, segment_search);
+log::debug!("Phase 2: Vector searches complete in {}ms", search_start.elapsed().as_millis());
+```
+
+#### 4. Add Timing in `select_fields()` (lines 1367, 1432)
+
+```rust
+// Line 1367 - cookbook retrieval
+log::debug!("Phase 3: Retrieving cookbook examples...");
+let cookbook_start = std::time::Instant::now();
+let examples = self.retrieve_cookbook_examples(user_query, 3).await?;
+log::debug!("Phase 3: Cookbook examples retrieved in {}ms", cookbook_start.elapsed().as_millis());
+
+// Line 1432 - LLM call (most likely bottleneck)
+log::debug!("Phase 3: Calling LLM for field selection...");
+let llm_start = std::time::Instant::now();
+let response = agent.prompt(&user_prompt).await?;
+log::debug!("Phase 3: LLM responded in {}ms", llm_start.elapsed().as_millis());
+```
+
+#### 5. Add Total Time Summary at End
+
+After all phases complete (around line 1021):
+
+```rust
+let generation_time_ms = start.elapsed().as_millis() as u64;
+log::info!(
+    "GAQL generation complete: total={}ms (Phase1={}ms, Phase2={}ms, Phase3={}ms)",
+    generation_time_ms,
+    phase1_time, phase2_time, phase3_time
+);
+```
+
+### Log Levels
+
+- `log::info!` - Phase start/complete with timing (visible by default with `-v`)
+- `log::debug!` - Sub-phase details (LLM calls, vector searches)
+
+### Expected Output Example
+
+```
+INFO  Phase 1: Resource selection...
+DEBUG Phase 1: Calling LLM for resource selection...
+DEBUG Phase 1: LLM responded in 2345ms
+INFO  Phase 1 complete: audience_view (2350ms)
+INFO  Phase 2: Retrieving field candidates...
+DEBUG Phase 2: Running 3 parallel vector searches...
+DEBUG Phase 2: Vector searches complete in 45ms
+INFO  Phase 2 complete: 47 candidates (48ms)
+DEBUG Phase 2.5: Pre-scan filters (2ms)
+INFO  Phase 3: Field selection via LLM...
+DEBUG Phase 3: Retrieving cookbook examples...
+DEBUG Phase 3: Cookbook examples retrieved in 12ms
+DEBUG Phase 3: Calling LLM for field selection...
+DEBUG Phase 3: LLM responded in 98234ms  <-- bottleneck identified!
+INFO  Phase 3 complete: 8 fields selected (98250ms)
+DEBUG Phase 4: Criteria assembly (1ms)
+DEBUG Phase 5: GAQL generation (0ms)
+INFO  GAQL generation complete: total=100651ms
+```
+
+## Verification
+
+1. Build: `cargo build -p mcc-gaql-gen`
+2. Run with verbose: `mcc-gaql-gen -v generate "show me campaigns with high CPA"`
+3. Verify timing logs appear for each phase
+4. Confirm the bottleneck is identifiable from the logs


### PR DESCRIPTION
### Summary

- **Timing instrumentation**: Add per-phase timing logs to the RAG pipeline so slow phases (especially LLM calls) are visible with `-v`
- **Clean GAQL output**: `generate` command now outputs only the GAQL query to stdout; all informational messages go through `log::` macros
- **Test isolation**: Rewrite field vector store tests to use temp directories, preventing tests from invalidating production cache hashes
- **LanceDB fix**: Remove explicit `.column("vector")` from `SearchParams` to suppress upstream deprecation warning
- **Optional query cookbook**: Add `--use-query-cookbook` flag to enable RAG search for cookbook examples (default: disabled for faster generation)
- **RAG transparency**: Add `--explain-selection-process` flag to print human-readable explanation of LLM-assisted RAG selection process (Phases 1-4)
- **Temporal date guidance**: Inject today's date and 12+ temporal period examples into LLM prompts for accurate date range generation
- **GaqlBuilder pattern**: Support DURING operator with proper WHERE clause handling

### Details

#### Timing Instrumentation (`rag.rs`)
Each pipeline phase now logs start/complete with elapsed ms at `INFO` level. Sub-operations (LLM calls, vector searches, cookbook retrieval) log at `DEBUG` level. Example output with `-v`:
```
INFO  Phase 1: Resource selection...
DEBUG Phase 1: Calling LLM for resource selection...
DEBUG Phase 1: LLM responded in 2345ms
INFO  Phase 1 complete: audience_view (2350ms)
INFO  Phase 2: Retrieving field candidates...
DEBUG Phase 2: Running 3 parallel vector searches...
DEBUG Phase 2: Vector searches complete in 45ms
INFO  Phase 2 complete: 47 candidates (48ms)
INFO  Phase 3: Field selection via LLM...
DEBUG Phase 3: LLM responded in 98234ms
INFO  Phase 3 complete: 8 fields selected (98250ms)
INFO  GAQL generation complete: total=100651ms (Phase1=2350ms, Phase2=48ms, Phase3=98250ms)
```

#### Clean GAQL Output (`main.rs`)
Previously `generate` printed "Generated GAQL:" header and inline messages to stdout, making it unsuitable for piping. Now only the query is printed to stdout.

#### Test Isolation (`field_vector_store_rag_tests.rs`)
Tests now use `tempfile::TempDir` so they never touch the production LanceDB cache or hash files.

#### Optional Query Cookbook (`rag.rs`, `main.rs`)
The `--use-query-cookbook` flag enables RAG search for query cookbook examples in Phase 3 LLM prompts. When disabled (default), the pipeline skips the cookbook vector search and excludes examples from prompts, resulting in:
- Faster generation (no cookbook vector search)
- Leaner prompts (~500-1000 tokens saved per example)
- Easier A/B testing of cookbook effectiveness

Usage:
```bash
# Default: Skip cookbook examples
mcc-gaql-gen generate "top 10 campaigns by clicks"

# Enable cookbook examples
mcc-gaql-gen generate --use-query-cookbook "top 10 campaigns by clicks"
```

#### RAG Transparency Flag (`rag.rs`, `main.rs`, `field_metadata.rs`)
The `--explain-selection-process` flag prints a detailed, human-readable explanation of the LLM selection process to stdout:
```
## Phase 1: Resource Selection (15730ms)
Model: hf:zai-org/GLM-4.7-Flash
LLM Reasoning: ...
Selected Primary Resource: ad_group_audience_view

## Phase 2: Field Candidate Retrieval (146ms)
Compatible Candidates: 10 fields

## Phase 3: Field Selection (8387ms)
Selected Fields: [...]
Filter Fields: [...]
Order By Fields: [...]

## Phase 4: Criteria Assembly
WHERE Clauses: [...]
```
Output is independent of logging system and unaffected by log level flags. Useful for debugging and understanding query generation behavior.

#### Temporal Date Guidance (`rag.rs`)
To prevent invalid date literals like `D-90`, the LLM prompt now:

1. Dynamically calculates today's date: `2026-03-15`
2. Pre-computes temporal period boundaries:
   - Rolling periods: last 7/30/60/90 days
   - Fixed periods: week/month/quarter/year (this/previous)
3. Injects these into both cookbook and non-cookbook prompts as examples:
   - `"last 90 days" → BETWEEN '2025-12-16' AND '2026-03-15'`
   - `"yesterday" → BETWEEN '2026-03-14' AND '2026-03-14'`
   - `"previous quarter" → BETWEEN '2025-10-01' AND '2025-12-31'`

Instructs LLM to use explicit `BETWEEN` with ISO dates instead of invalid relative literals.

#### DURING Operator Support (`rag.rs`, `GaqlBuilder`)
- `GaqlBuilder` now accepts DURING filters with proper WHERE clause generation
- DURING filters are handled without quotes: `segments.date DURING LAST_30_DAYS`
- Other operators continue using quoted values: `campaign.status = 'ENABLED'`

#### Configuration Changes (replaced flags with env var)
- Originally implemented `--trace` flag for full LLM prompt logging
- Reverted in favor of `MCC_GAQL_LOG_LEVEL=trace` environment variable
- Cleaner configuration: CLI for user-facing flags, env vars for debugging