### PR TITLE
Fix bootstrap download tempfile and symlink issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           MCC_GAQL_EMBED_CLIENT_SECRET: ${{ secrets.GOOGLE_ADS_CLIENT_SECRET }}
           MCC_GAQL_DEV_TOKEN: ${{ secrets.GOOGLE_ADS_DEV_TOKEN }}
+          MCC_GAQL_R2_PUBLIC_ID: ${{ vars.MCC_GAQL_R2_PUBLIC_ID }}
         run: cargo build -p mcc-gaql-gen --release --target aarch64-apple-darwin
 
       - name: Extract version from tag

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,8 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       needs.changes.outputs.gen == 'true'
+    env:
+      MCC_GAQL_R2_PUBLIC_ID: ${{ vars.MCC_GAQL_R2_PUBLIC_ID }}
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain

--- a/crates/mcc-gaql-gen/src/bundle.rs
+++ b/crates/mcc-gaql-gen/src/bundle.rs
@@ -52,16 +52,15 @@ pub struct ManifestFile {
 }
 
 /// Extracted bundle info
-#[derive(Debug)]
 pub struct ExtractedBundle {
     pub manifest: Manifest,
-    pub temp_dir: PathBuf,
+    pub temp_dir: tempfile::TempDir,
 }
 
 impl ExtractedBundle {
     /// Get the full path to a file in the extracted bundle
     pub fn file_path(&self, relative_path: &str) -> PathBuf {
-        self.temp_dir.join(relative_path)
+        self.temp_dir.path().join(relative_path)
     }
 }
 
@@ -241,7 +240,6 @@ pub async fn create_bundle(output_path: &Path, query_cookbook_path: &Path) -> Re
 pub async fn extract_bundle(bundle_path: &Path, skip_validation: bool) -> Result<ExtractedBundle> {
     // Create temp directory for extraction
     let temp_dir = tempfile::tempdir().context("Failed to create temp directory")?;
-    let temp_path = temp_dir.path().to_path_buf();
 
     // Open and extract tar.gz
     let tar_gz = File::open(bundle_path)?;
@@ -249,11 +247,20 @@ pub async fn extract_bundle(bundle_path: &Path, skip_validation: bool) -> Result
     let mut archive = Archive::new(dec);
 
     archive
-        .unpack(&temp_path)
+        .unpack(temp_dir.path())
         .context("Failed to extract bundle")?;
 
+    log::debug!("extract_bundle: extracted to {:?}", temp_dir.path());
+
+    // Log extracted files for debugging
+    if let Ok(mut entries) = std::fs::read_dir(temp_dir.path()) {
+        while let Some(Ok(entry)) = entries.next() {
+            log::debug!("extract_bundle: found {:?}", entry.file_name());
+        }
+    }
+
     // Load and validate manifest
-    let manifest_path = temp_path.join("manifest.json");
+    let manifest_path = temp_dir.path().join("manifest.json");
     if !manifest_path.exists() {
         anyhow::bail!("Bundle missing manifest.json");
     }
@@ -264,7 +271,7 @@ pub async fn extract_bundle(bundle_path: &Path, skip_validation: bool) -> Result
 
     // Validate checksums if requested
     if !skip_validation {
-        validate_checksums(&manifest, &temp_path)?;
+        validate_checksums(&manifest, temp_dir.path())?;
     }
 
     // Check CLI version compatibility
@@ -283,7 +290,7 @@ pub async fn extract_bundle(bundle_path: &Path, skip_validation: bool) -> Result
 
     Ok(ExtractedBundle {
         manifest,
-        temp_dir: temp_path,
+        temp_dir,
     })
 }
 
@@ -325,7 +332,8 @@ pub async fn download_bundle(url: &str) -> Result<PathBuf> {
     file.write_all(&bytes)?;
 
     log::info!("Downloaded {} bytes to temp file", bytes.len());
-    Ok(temp_path.to_path_buf())
+    let path = temp_path.keep().context("Failed to persist temp file")?;
+    Ok(path)
 }
 
 /// Copy files from extracted bundle to cache and config directories
@@ -335,9 +343,19 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
     let config_dir =
         mcc_gaql_common::paths::config_dir().context("Could not determine config directory")?;
 
+    log::debug!("install_bundle: cache_dir={:?}", cache_dir);
+    log::debug!("install_bundle: config_dir={:?}", config_dir);
+    log::debug!("install_bundle: bundle temp_dir={:?}", bundle.temp_dir.path());
+
     // Ensure directories exist
-    fs::create_dir_all(&cache_dir).await?;
-    fs::create_dir_all(&config_dir).await?;
+    fs::create_dir_all(&cache_dir)
+        .await
+        .with_context(|| format!("Failed to create cache directory: {:?}", cache_dir))?;
+    fs::create_dir_all(&config_dir)
+        .await
+        .with_context(|| format!("Failed to create config directory: {:?}", config_dir))?;
+
+    log::debug!("install_bundle: directories created/verified");
 
     // Check if cache already exists and is valid (unless --force)
     if !force {
@@ -358,22 +376,49 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
     // Copy field_metadata_enriched.json to cache
     let enriched_src = bundle.file_path("field_metadata_enriched.json");
     let enriched_dest = cache_dir.join("field_metadata_enriched.json");
+    log::debug!("install_bundle: copying {:?} -> {:?}", enriched_src, enriched_dest);
+    log::debug!("install_bundle: enriched_src exists={}", enriched_src.exists());
     fs::copy(&enriched_src, &enriched_dest)
         .await
-        .context("Failed to copy enriched metadata to cache")?;
+        .with_context(|| {
+            format!(
+                "Failed to copy enriched metadata: {:?} -> {:?}",
+                enriched_src, enriched_dest
+            )
+        })?;
     log::info!("Installed field_metadata_enriched.json");
 
     // Copy query_cookbook.toml to config
     let cookbook_src = bundle.file_path("query_cookbook.toml");
     let cookbook_dest = config_dir.join("query_cookbook.toml");
-    fs::copy(&cookbook_src, &cookbook_dest)
-        .await
-        .context("Failed to copy query cookbook to config")?;
-    log::info!("Installed query_cookbook.toml");
+    log::debug!("install_bundle: copying {:?} -> {:?}", cookbook_src, cookbook_dest);
+    log::debug!("install_bundle: cookbook_src exists={}", cookbook_src.exists());
+    if cookbook_src.exists() {
+        // Remove existing file/symlink at destination to avoid broken-symlink errors
+        if cookbook_dest.exists() || cookbook_dest.symlink_metadata().is_ok() {
+            fs::remove_file(&cookbook_dest).await.with_context(|| {
+                format!("Failed to remove existing {:?}", cookbook_dest)
+            })?;
+            log::debug!("install_bundle: removed existing {:?}", cookbook_dest);
+        }
+        fs::copy(&cookbook_src, &cookbook_dest)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to copy query cookbook: {:?} -> {:?}",
+                    cookbook_src, cookbook_dest
+                )
+            })?;
+        log::info!("Installed query_cookbook.toml");
+    } else {
+        log::warn!("query_cookbook.toml not found in bundle, skipping");
+    }
 
     // Copy LanceDB directory
     let lancedb_src = bundle.file_path("lancedb");
     let lancedb_dest = cache_dir.join("lancedb");
+    log::debug!("install_bundle: copying lancedb {:?} -> {:?}", lancedb_src, lancedb_dest);
+    log::debug!("install_bundle: lancedb_src exists={}", lancedb_src.exists());
 
     // Remove existing LanceDB if it exists
     if lancedb_dest.exists() {
@@ -382,19 +427,38 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
 
     copy_dir_all(&lancedb_src, &lancedb_dest)
         .await
-        .context("Failed to copy LanceDB to cache")?;
+        .with_context(|| {
+            format!(
+                "Failed to copy LanceDB: {:?} -> {:?}",
+                lancedb_src, lancedb_dest
+            )
+        })?;
     log::info!("Installed lancedb/");
 
     // Copy hash files
     let field_hash_src = bundle.file_path("field_metadata.hash");
+    log::debug!(
+        "install_bundle: field_metadata.hash exists={}",
+        field_hash_src.exists()
+    );
     if field_hash_src.exists() {
-        fs::copy(&field_hash_src, cache_dir.join("field_metadata.hash")).await?;
+        let dest = cache_dir.join("field_metadata.hash");
+        fs::copy(&field_hash_src, &dest).await.with_context(|| {
+            format!("Failed to copy field_metadata.hash: {:?} -> {:?}", field_hash_src, dest)
+        })?;
         log::info!("Installed field_metadata.hash");
     }
 
     let query_hash_src = bundle.file_path("query_cookbook.hash");
+    log::debug!(
+        "install_bundle: query_cookbook.hash exists={}",
+        query_hash_src.exists()
+    );
     if query_hash_src.exists() {
-        fs::copy(&query_hash_src, cache_dir.join("query_cookbook.hash")).await?;
+        let dest = cache_dir.join("query_cookbook.hash");
+        fs::copy(&query_hash_src, &dest).await.with_context(|| {
+            format!("Failed to copy query_cookbook.hash: {:?} -> {:?}", query_hash_src, dest)
+        })?;
         log::info!("Installed query_cookbook.hash");
     }
 

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -163,10 +163,6 @@ enum Commands {
 
     /// Download pre-built RAG resources for instant GAQL generation
     Bootstrap {
-        /// Public URL for the bundle
-        #[arg(long, env = "MCC_GAQL_BUNDLE_URL")]
-        url: Option<String>,
-
         /// API version to download
         #[arg(long, default_value = "v23")]
         version: String,
@@ -326,13 +322,12 @@ async fn main() -> Result<()> {
         }
 
         Commands::Bootstrap {
-            url,
             version,
             force,
             skip_validation,
             verify_only,
         } => {
-            cmd_bootstrap(url, version, force, skip_validation, verify_only).await?;
+            cmd_bootstrap(version, force, skip_validation, verify_only).await?;
         }
 
         Commands::Publish {
@@ -953,16 +948,12 @@ async fn cmd_index(queries: Option<String>, metadata: Option<PathBuf>) -> Result
 
 /// Download pre-built RAG resources for instant GAQL generation
 async fn cmd_bootstrap(
-    url: Option<String>,
-    _version: String,
+    version: String,
     force: bool,
     skip_validation: bool,
     verify_only: bool,
 ) -> Result<()> {
-    // Get bundle URL
-    let bundle_url = url
-        .or_else(|| env::var("MCC_GAQL_BUNDLE_URL").ok())
-        .context("Bundle URL not configured. Set MCC_GAQL_BUNDLE_URL or use --url")?;
+    let bundle_url = r2::public_bundle_url(&format!("mcc-gaql-rag-bundle-{}.tar.gz", version));
 
     // Check current cache status if verify-only or to determine if download needed
     let verification = bundle::verify_cache().await?;
@@ -1100,7 +1091,7 @@ async fn cmd_publish(key: String, dry_run: bool, queries: Option<PathBuf>) -> Re
     println!("\n✓ Publish complete!");
     println!("  Public URL: {}", public_url);
     println!("\nUsers can now run:");
-    println!("  mcc-gaql-gen bootstrap --url {}", public_url);
+    println!("  mcc-gaql-gen bootstrap");
 
     Ok(())
 }

--- a/crates/mcc-gaql-gen/src/r2.rs
+++ b/crates/mcc-gaql-gen/src/r2.rs
@@ -8,6 +8,9 @@ use anyhow::{Context, Result};
 use std::path::Path;
 use tokio::fs;
 
+/// R2 public bucket ID, required at build time
+const R2_PUBLIC_ID: &str = env!("MCC_GAQL_R2_PUBLIC_ID");
+
 /// R2 bucket configuration
 struct R2Config {
     endpoint_url: String,
@@ -93,22 +96,9 @@ pub async fn upload_bundle(local_path: &Path, object_key: &str) -> Result<String
     upload(object_key, local_path).await?;
 
     // Construct public URL
-    let public_url = format!(
-        "https://pub-{}.r2.dev/{}",
-        get_account_hash().unwrap_or_else(|_| "dev".to_string()),
-        object_key
-    );
+    let public_url = format!("https://pub-{}.r2.dev/{}", R2_PUBLIC_ID, object_key);
 
     Ok(public_url)
-}
-
-/// Get a hash of the account ID for public URL construction
-fn get_account_hash() -> Result<String> {
-    // In practice, this would come from the R2 configuration
-    // For now, we return a placeholder that users can customize
-    // The actual public URL is provided by R2 and can be configured via env var
-    std::env::var("MCC_GAQL_R2_PUBLIC_ID")
-        .map_err(|_| anyhow::anyhow!("MCC_GAQL_R2_PUBLIC_ID not set (used for public URL)"))
 }
 
 /// Download a bundle from a public URL (no auth required)

--- a/crates/mcc-gaql-gen/src/r2.rs
+++ b/crates/mcc-gaql-gen/src/r2.rs
@@ -11,6 +11,11 @@ use tokio::fs;
 /// R2 public bucket ID, required at build time
 const R2_PUBLIC_ID: &str = env!("MCC_GAQL_R2_PUBLIC_ID");
 
+/// Returns the public URL for a bundle object in R2.
+pub fn public_bundle_url(object_key: &str) -> String {
+    format!("https://pub-{}.r2.dev/{}", R2_PUBLIC_ID, object_key)
+}
+
 /// R2 bucket configuration
 struct R2Config {
     endpoint_url: String,


### PR DESCRIPTION
## Summary

Fixes multiple file handling bugs in the `mcc-gaql-gen bootstrap` command that caused "No such file or directory" errors.

## Changes

### 1. Hardcode R2 public ID at build time
- Remove `--url` flag and `MCC_GAQL_BUNDLE_URL` env var from bootstrap command
- Bundle URL now derived from hardcoded `MCC_GAQL_R2_PUBLIC_ID` set at compile time
- Simpler UX: users just run `mcc-gaql-gen bootstrap` without needing to know URLs

### 2. Fix tempfile drop-before-use bugs
- **Bug 1:** `TempPath` dropped before extraction - fixed with `temp_path.keep()`
- **Bug 2:** `TempDir` dropped before files could be copied - fixed by storing `tempfile::TempDir` in `ExtractedBundle` struct

### 3. Handle broken symlinks when copying query_cookbook.toml
- Remove existing file/symlink at destination before copying (prevents "No such file or directory" errors)

### 4. Add DEBUG-level logging
- Trace all file operations with `RUST_LOG=debug mcc-gaql-gen bootstrap`

## Files Changed
- `crates/mcc-gaql-gen/src/bundle.rs` - Tempfile fixes, symlink handling, debug logging
- `crates/mcc-gaql-gen/src/main.rs` - Remove --url flag
- `crates/mcc-gaql-gen/src/r2.rs` - Build-time R2_PUBLIC_ID
