### PR TITLE
Migrate to googleads-rs v23.2.0 (github main)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2519,7 +2519,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2648,7 +2648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3319,6 +3319,7 @@ dependencies = [
 [[package]]
 name = "googleads-rs"
 version = "23.2.0"
+source = "git+https://github.com/mhuang74/googleads-rs?branch=main#9c5f4a4bb59fce7b860c3a5c3d30f0461f31cd79"
 dependencies = [
  "build-print",
  "bytes",
@@ -3332,6 +3333,7 @@ dependencies = [
  "tonic-prost",
  "tonic-prost-build",
  "walkdir",
+ "which",
 ]
 
 [[package]]
@@ -3732,7 +3734,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4111,7 +4113,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5455,7 +5457,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6671,8 +6673,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -6691,8 +6693,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6713,7 +6715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6726,7 +6728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6824,7 +6826,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6862,7 +6864,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7470,7 +7472,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7571,7 +7573,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8081,7 +8083,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8110,7 +8112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8584,7 +8586,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9634,6 +9636,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9655,7 +9669,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10035,6 +10049,12 @@ checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3318,12 +3318,14 @@ dependencies = [
 
 [[package]]
 name = "googleads-rs"
-version = "0.13.0"
-source = "git+https://github.com/mhuang74/googleads-rs.git?branch=main#de396cc998798927164917b78ebd81a3a4e455fb"
+version = "23.2.0"
 dependencies = [
  "build-print",
+ "bytes",
+ "once_cell",
  "prost 0.14.3",
  "prost-build 0.14.3",
+ "prost-reflect",
  "prost-types 0.14.3",
  "tonic",
  "tonic-build",
@@ -5083,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "mcc-gaql"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5114,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "mcc-gaql-common"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5132,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "mcc-gaql-gen"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -6728,6 +6730,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Michael S. Huang <mhuang74@gmail.com>"]
 edition = "2024"
-version = "0.16.5"
+version = "0.17.0"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/crates/mcc-gaql/Cargo.toml
+++ b/crates/mcc-gaql/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "3.1", features = ["derive", "cargo"] }
 dialoguer = "0.11"
 figment = { version = "0.10", features = ["toml", "env"] }
 flexi_logger = { version = "0.22", features = ["compress"] }
-googleads-rs = { version = "0.13.0", git = "https://github.com/mhuang74/googleads-rs.git", branch = "main" }
+googleads-rs = { version = "23.2.0", path = "../../../googleads_rs_support_all_field_opus" }
 itertools = "0.10"
 polars = { version = "0.42", default-features = false, features = ["lazy", "fmt", "csv"] }
 thousands = "0.2"

--- a/crates/mcc-gaql/Cargo.toml
+++ b/crates/mcc-gaql/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "3.1", features = ["derive", "cargo"] }
 dialoguer = "0.11"
 figment = { version = "0.10", features = ["toml", "env"] }
 flexi_logger = { version = "0.22", features = ["compress"] }
-googleads-rs = { version = "23.2.0", path = "../../../googleads_rs_support_all_field_opus" }
+googleads-rs = { git = "https://github.com/mhuang74/googleads-rs", branch = "main" }
 itertools = "0.10"
 polars = { version = "0.42", default-features = false, features = ["lazy", "fmt", "csv"] }
 thousands = "0.2"

--- a/crates/mcc-gaql/src/field_metadata.rs
+++ b/crates/mcc-gaql/src/field_metadata.rs
@@ -90,9 +90,10 @@ pub async fn fetch_from_api(api_context: &GoogleAdsAPIAccess) -> Result<FieldMet
             5 => "SEGMENT",
             6 => "METRIC",
             _ => {
-                if row.name.starts_with("metrics.") {
+                let name = row.name.as_ref().expect("GoogleAdsField must have a name");
+                if name.starts_with("metrics.") {
                     "METRIC"
-                } else if row.name.starts_with("segments.") {
+                } else if name.starts_with("segments.") {
                     "SEGMENT"
                 } else {
                     "UNKNOWN"
@@ -124,13 +125,15 @@ pub async fn fetch_from_api(api_context: &GoogleAdsAPIAccess) -> Result<FieldMet
 
         let metrics_compatible = category == "ATTRIBUTE" || category == "SEGMENT";
 
+        let field_name = row.name.clone().expect("GoogleAdsField must have a name");
+
         let field_meta = FieldMetadata {
-            name: row.name.clone(),
+            name: field_name.clone(),
             category,
             data_type,
-            selectable: row.selectable,
-            filterable: row.filterable,
-            sortable: row.sortable,
+            selectable: row.selectable.unwrap_or(false),
+            filterable: row.filterable.unwrap_or(false),
+            sortable: row.sortable.unwrap_or(false),
             metrics_compatible,
             resource_name: if row.resource_name.is_empty() {
                 None
@@ -149,10 +152,10 @@ pub async fn fetch_from_api(api_context: &GoogleAdsAPIAccess) -> Result<FieldMet
             resources
                 .entry(resource)
                 .or_default()
-                .push(row.name.clone());
+                .push(field_name.clone());
         }
 
-        fields.insert(row.name, field_meta);
+        fields.insert(field_name, field_meta);
     }
 
     log::info!(

--- a/crates/mcc-gaql/src/googleads.rs
+++ b/crates/mcc-gaql/src/googleads.rs
@@ -483,10 +483,10 @@ pub async fn fields_query(api_context: GoogleAdsAPIAccess, query: &str) {
     for row in response.results {
         let val = format!(
             "{}\t{:?}\t{}\t{}\t{:?}\n",
-            row.name,
+            row.name.as_deref().unwrap_or(""),
             row.category(),
-            row.selectable,
-            row.filterable,
+            row.selectable.unwrap_or(false),
+            row.filterable.unwrap_or(false),
             row.selectable_with,
         );
         stdout.write_all(val.as_bytes()).await.unwrap();


### PR DESCRIPTION
## Summary

- Migrate googleads-rs dependency from GitHub repository (v0.13.0) to local path dependency (v23.2.0)
- Update code to handle breaking API changes where GoogleAdsField properties are now wrapped in Option types
- Bump workspace version to 0.17.0

## Changes

**Dependency Update:**
- Changed `crates/mcc-gaql/Cargo.toml` to use local path: `../../../googleads_rs_support_all_field_opus`
- Updated from v0.13.0 (git) to v23.2.0 (local)

**API Compatibility Fixes:**
- `field_metadata.rs`: Handle Option-wrapped fields (name, selectable, filterable, sortable)
- `googleads.rs`: Update fields_query to unwrap Option types with appropriate defaults
- Added `prost-reflect` dependency (required by new googleads-rs version)

## Test plan

- [x] `cargo check --workspace` passes
- [ ] `cargo build -p mcc-gaql --release` succeeds
- [ ] `cargo test -p mcc-gaql -- --test-threads=1` passes
- [ ] Manual testing with field metadata fetching