### PR TITLE
feat: optimize enrich command to only process resources missing enrichment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,10 @@ jobs:
         run: brew install protobuf
 
       - name: Build mcc-gaql release binary
-        env:
-          MCC_GAQL_EMBED_CLIENT_SECRET: ${{ secrets.GOOGLE_ADS_CLIENT_SECRET }}
-          MCC_GAQL_DEV_TOKEN: ${{ secrets.GOOGLE_ADS_DEV_TOKEN }}
         run: cargo build -p mcc-gaql --release --target aarch64-apple-darwin
 
       - name: Build mcc-gaql-gen release binary
         env:
-          MCC_GAQL_EMBED_CLIENT_SECRET: ${{ secrets.GOOGLE_ADS_CLIENT_SECRET }}
-          MCC_GAQL_DEV_TOKEN: ${{ secrets.GOOGLE_ADS_DEV_TOKEN }}
           MCC_GAQL_R2_PUBLIC_ID: ${{ vars.MCC_GAQL_R2_PUBLIC_ID }}
         run: cargo build -p mcc-gaql-gen --release --target aarch64-apple-darwin
 
@@ -66,15 +61,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install protobuf-compiler libssl-dev
 
       - name: Build mcc-gaql release binary
-        env:
-          MCC_GAQL_EMBED_CLIENT_SECRET: ${{ secrets.GOOGLE_ADS_CLIENT_SECRET }}
-          MCC_GAQL_DEV_TOKEN: ${{ secrets.GOOGLE_ADS_DEV_TOKEN }}
         run: cargo build -p mcc-gaql --release
 
       - name: Build mcc-gaql-gen release binary
         env:
-          MCC_GAQL_EMBED_CLIENT_SECRET: ${{ secrets.GOOGLE_ADS_CLIENT_SECRET }}
-          MCC_GAQL_DEV_TOKEN: ${{ secrets.GOOGLE_ADS_DEV_TOKEN }}
           MCC_GAQL_R2_PUBLIC_ID: ${{ vars.MCC_GAQL_R2_PUBLIC_ID }}
         run: cargo build -p mcc-gaql-gen --release
 
@@ -109,15 +99,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install protobuf-compiler libssl-dev
 
       - name: Build mcc-gaql release binary
-        env:
-          MCC_GAQL_EMBED_CLIENT_SECRET: ${{ secrets.GOOGLE_ADS_CLIENT_SECRET }}
-          MCC_GAQL_DEV_TOKEN: ${{ secrets.GOOGLE_ADS_DEV_TOKEN }}
         run: cargo build -p mcc-gaql --release
 
       - name: Build mcc-gaql-gen release binary
         env:
-          MCC_GAQL_EMBED_CLIENT_SECRET: ${{ secrets.GOOGLE_ADS_CLIENT_SECRET }}
-          MCC_GAQL_DEV_TOKEN: ${{ secrets.GOOGLE_ADS_DEV_TOKEN }}
           MCC_GAQL_R2_PUBLIC_ID: ${{ vars.MCC_GAQL_R2_PUBLIC_ID }}
         run: cargo build -p mcc-gaql-gen --release
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "mcc-gaql"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "mcc-gaql-common"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "mcc-gaql-gen"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Michael S. Huang <mhuang74@gmail.com>"]
 edition = "2024"
-version = "0.17.0"
+version = "0.17.1"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -151,11 +151,8 @@ cargo build --workspace
 cargo build -p mcc-gaql --release
 
 # Build GAQL generation tool (slow, ~400 MB)
-cargo build -p mcc-gaql-gen --release
-
-# Build release with embedded credentials
-MCC_GAQL_DEV_TOKEN="token" MCC_GAQL_EMBED_CLIENT_SECRET="$(cat clientsecret.json)" \
-  cargo build -p mcc-gaql --release
+# Note: MCC_GAQL_R2_PUBLIC_ID required at build time
+MCC_GAQL_R2_PUBLIC_ID="your_public_id" cargo build -p mcc-gaql-gen --release
 ```
 
 ### Running Tests
@@ -210,23 +207,16 @@ cargo clippy --workspace
 
 ## Build-Time Environment Variables
 
-The following variables are embedded in the binary at build time:
+The following variable is required at build time for `mcc-gaql-gen`:
 
 | Variable | Purpose |
 |----------|---------|
-| `MCC_GAQL_DEV_TOKEN` | Google Ads developer token (optional) |
-| `MCC_GAQL_EMBED_CLIENT_SECRET` | OAuth2 client secret JSON (optional) |
-| `MCC_GAQL_R2_PUBLIC_ID` | Hashed Cloudflare R2 public bucket ID for bootstrap downloads |
+| `MCC_GAQL_R2_PUBLIC_ID` | Hashed Cloudflare R2 public bucket ID for bootstrap downloads (required for mcc-gaql-gen) |
 
-### Embedding Credentials in Release Builds
-
-For distribution within an organization, you can embed credentials directly in the binary:
-
-```bash
-export MCC_GAQL_DEV_TOKEN="your_dev_token"
-export MCC_GAQL_EMBED_CLIENT_SECRET="$(cat clientsecret.json)"
-cargo build -p mcc-gaql --release
-```
+**Note:** `MCC_GAQL_DEV_TOKEN` and `MCC_GAQL_EMBED_CLIENT_SECRET` are NOT embedded at build time for security reasons. These must be provided at runtime via:
+- Environment variables
+- Config file (`dev_token` field)
+- `clientsecret.json` file in config directory
 
 ### Embedding R2 Public ID for Bootstrap
 

--- a/METADATA_MAINTENANCE.md
+++ b/METADATA_MAINTENANCE.md
@@ -1,0 +1,330 @@
+# Metadata Maintenance Guide
+
+This guide is for maintainers and developers who need to build or rebuild the Google Ads field metadata cache. Most users should use `mcc-gaql-gen bootstrap` to download pre-built metadata instead.
+
+## When to Run This Workflow
+
+Run the metadata maintenance workflow when:
+- Upgrading to a new Google Ads API version (via googleads-rs crate update)
+- New resources or fields are available but not yet in the cache
+- The LLM-generated field descriptions need improvement
+- Publishing updated metadata for others to use via `bootstrap`
+
+## Prerequisites
+
+- Ability to build `mcc-gaql-gen` from source (proto files come from build dependencies)
+- Valid Google Ads API credentials (for `--refresh-field-cache`)
+- LLM API credentials configured (for `enrich` command)
+- R2/S3 credentials (only if publishing metadata bundles)
+
+## The 5-Step Metadata Pipeline
+
+### Step 1: Refresh Field Cache
+
+```bash
+mcc-gaql --refresh-field-cache
+```
+
+**Purpose:** Fetches all available resources and fields from the currently supported Google Ads API version.
+
+**Who can run:** Anyone with valid Google Ads API credentials.
+
+**Output:** `field_metadata.json` in your config directory.
+
+**What it does:** Queries the Google Ads API FieldService to retrieve:
+- All available resource types (campaign, ad_group, etc.)
+- All available fields for each resource
+- Field data types and categorization (METRIC, ATTRIBUTE, SEGMENT)
+- Which fields are filterable, sortable, and selectable
+
+---
+
+### Step 2: Parse Proto Files
+
+```bash
+mcc-gaql-gen parse-protos
+```
+
+**Purpose:** Extracts field documentation from Google's official proto files bundled with the googleads-rs crate.
+
+**Who can run:** Only developers who can build `mcc-gaql-gen` from source. The proto files are located in the Cargo registry/git checkouts and are not available in pre-built binaries.
+
+**Output:** `proto_docs_v23.json` in your cache directory containing:
+- ~182 resource messages with ~3000 fields
+- ~360 enums with ~1200 values
+- Field behavior annotations (IMMUTABLE, OUTPUT_ONLY, REQUIRED, OPTIONAL)
+- Official Google documentation strings
+
+**Options:**
+- `--force` - Rebuild cache even if it exists
+- `--output <PATH>` - Custom output path
+
+**Proto file location:**
+```
+$CARGO_HOME/git/checkouts/googleads-rs-*/proto/google/ads/googleads/v23/
+```
+
+---
+
+### Step 3: Enrich Metadata
+
+```bash
+# Using LLM for semantic enrichment (recommended)
+mcc-gaql-gen enrich
+
+# Using proto documentation only (faster, no LLM calls)
+mcc-gaql-gen enrich --use-proto
+```
+
+**Purpose:** Enriches field metadata with human-readable descriptions and semantic context.
+
+**Who can run:** Anyone with LLM credentials configured (unless using `--use-proto`).
+
+**Output:** `field_metadata_enriched.json` - enhanced version of field metadata.
+
+**What it does:**
+- Merges proto documentation into field metadata
+- (Without `--use-proto`) Uses LLM to generate improved descriptions based on field names and proto comments
+- Adds semantic context to help natural language query generation
+
+**Requirements for LLM mode:**
+- `MCC_GAQL_LLM_API_KEY`
+- `MCC_GAQL_LLM_BASE_URL`
+- `MCC_GAQL_LLM_MODEL`
+
+#### Multiple Models for Concurrent Processing
+
+You can specify multiple comma-separated models in `MCC_GAQL_LLM_MODEL` to enable concurrent processing during **field metadata enrichment**. When multiple models are configured, the tool uses a model pool to parallelize LLM calls, significantly speeding up the enrichment process.
+
+**How it works:**
+- Each model gets one concurrent "slot" (rate-limiting per model)
+- Batches of fields are distributed across all available models
+- If a model is busy, work is automatically routed to the next available model
+- The first model in the list is considered the "preferred" model for single-model operations
+
+**Example with multiple models:**
+```bash
+# Use multiple models concurrently for faster metadata enrichment
+export MCC_GAQL_LLM_API_KEY="your_openrouter_api_key"
+export MCC_GAQL_LLM_BASE_URL="https://openrouter.ai/api/v1"
+export MCC_GAQL_LLM_MODEL="google/gemini-flash-2.0,openai/gpt-4o-mini,anthropic/claude-3.5-haiku"
+
+# Now when you enrich metadata, enrichment happens in parallel across all 3 models
+mcc-gaql-gen enrich
+```
+
+> **Note:** Multiple models are only used for field metadata enrichment operations. Natural language query generation always uses the first (preferred) model.
+
+---
+
+### Step 4: Index for RAG
+
+```bash
+mcc-gaql-gen index
+```
+
+**Purpose:** Populates the LanceDB vector database with enriched metadata for fast similarity search during natural language query generation.
+
+**Who can run:** Anyone with the enriched metadata file.
+
+**Output:** Vector embeddings stored in `~/.cache/mcc-gaql/lancedb/`.
+
+**What it does:**
+- Generates embeddings for all resources and fields using FastEmbed
+- Stores vectors in LanceDB for efficient similarity search
+- Enables semantic retrieval of relevant fields during `generate` command
+
+**Time:** Takes a few minutes depending on your hardware.
+
+---
+
+### Step 5: Publish Bundle
+
+```bash
+# Create and upload to R2
+mcc-gaql-gen publish
+
+# Create locally without uploading (dry run)
+mcc-gaql-gen publish --dry-run
+```
+
+**Purpose:** Creates a metadata bundle and uploads it to R2 storage for distribution via `mcc-gaql-gen bootstrap`.
+
+**Who can run:**
+- **Repo owner:** Can publish to the default R2 URL (hardcoded in binary)
+- **Anyone:** Can publish to a custom R2/S3 bucket and configure `bootstrap` to use it
+
+**Requirements:**
+- `MCC_GAQL_R2_ACCESS_KEY_ID`
+- `MCC_GAQL_R2_SECRET_ACCESS_KEY`
+- `MCC_GAQL_R2_BUCKET`
+- `MCC_GAQL_R2_ENDPOINT_URL`
+
+**Custom bucket workflow:**
+```bash
+# Publish to your own bucket
+export MCC_GAQL_R2_ENDPOINT_URL="https://your-account.r2.cloudflarestorage.com"
+export MCC_GAQL_R2_BUCKET="your-bucket"
+mcc-gaql-gen publish
+
+# Users can then bootstrap from your bucket
+export MCC_GAQL_R2_PUBLIC_ID="your-public-bucket-id"
+mcc-gaql-gen bootstrap
+```
+
+---
+
+## Additional Commands
+
+### Display Metadata
+
+```bash
+# Show metadata for a specific resource
+mcc-gaql-gen metadata campaign
+
+# Show all fields (not just LLM-limited subset)
+mcc-gaql-gen metadata campaign --show-all
+
+# Compare enriched vs non-enriched
+mcc-gaql-gen metadata campaign --diff
+```
+
+**Purpose:** Debug and inspect enriched field metadata.
+
+---
+
+### Clear Cache
+
+```bash
+mcc-gaql-gen clear-cache
+```
+
+**Purpose:** Removes the local LanceDB vector cache. Useful when:
+- Rebuilding from scratch
+- Debugging embedding issues
+- Freeing disk space
+
+**Note:** This only clears the vector cache. Proto docs and enriched metadata files remain.
+
+---
+
+## Debugging Metadata Issues
+
+### Checking if Metadata is Stale
+
+Compare the API version in your metadata with Google's current version:
+
+```bash
+# Check what version your metadata was built for
+head ~/.cache/mcc-gaql/field_metadata_enriched.json
+
+# Compare with the version in googleads-rs
+grep "googleads-rs" Cargo.lock
+```
+
+### Verifying Proto Parsing
+
+```bash
+# Check proto docs exist and have content
+ls -la ~/.cache/mcc-gaql/proto_docs_v23.json
+wc -l ~/.cache/mcc-gaql/proto_docs_v23.json
+
+# Verify parsing worked
+grep -c "message" ~/.cache/mcc-gaql/proto_docs_v23.json
+```
+
+### Checking LanceDB Contents
+
+```bash
+# Check LanceDB directory exists and has content
+ls -la ~/.cache/mcc-gaql/lancedb/
+
+# The directory should contain .lance files
+find ~/.cache/mcc-gaql/lancedb -name "*.lance" | wc -l
+```
+
+### Common Issues
+
+**Issue:** `parse-protos` fails with "proto files not found"
+- **Cause:** You may not have built the project from source
+- **Fix:** Run `cargo build -p mcc-gaql-gen` first to fetch dependencies
+
+**Issue:** `enrich` fails with LLM errors
+- **Cause:** LLM credentials not configured
+- **Fix:** Set `MCC_GAQL_LLM_API_KEY`, `MCC_GAQL_LLM_BASE_URL`, and `MCC_GAQL_LLM_MODEL`
+- **Workaround:** Use `mcc-gaql-gen enrich --use-proto` for proto-only enrichment
+
+**Issue:** `index` takes very long or runs out of memory
+- **Cause:** FastEmbed model download or embedding generation
+- **Fix:** Ensure sufficient disk space (~2GB) and RAM (~4GB)
+
+**Issue:** `publish` fails with access denied
+- **Cause:** Missing or incorrect R2 credentials
+- **Fix:** Verify all `MCC_GAQL_R2_*` environment variables
+
+---
+
+## File Reference
+
+| File | Location | Purpose |
+|------|----------|---------|
+| Field metadata | `~/.config/mcc-gaql/field_metadata.json` | Raw field metadata from Google Ads API |
+| Enriched metadata | `~/.cache/mcc-gaql/field_metadata_enriched.json` | Metadata with descriptions (used for generation) |
+| Proto docs | `~/.cache/mcc-gaql/proto_docs_v23.json` | Parsed proto documentation |
+| LanceDB | `~/.cache/mcc-gaql/lancedb/` | Vector embeddings for RAG search |
+| Scraped docs | `~/.config/mcc-gaql/scraped_docs.json` | Legacy: web-scraped documentation (deprecated) |
+
+---
+
+## Proto Parsing vs Web Scraping
+
+The tool supports two methods for extracting field documentation:
+
+| Approach | Status | Description |
+|----------|--------|-------------|
+| **Proto Parsing** (Recommended) | Stable | Parses Google's official proto files from `googleads-rs` crate - authoritative source |
+| **Web Scraping** | Deprecated | Scrapes HTML documentation from Google's developer website - unreliable |
+
+### Proto Parsing (Recommended)
+
+**Advantages:**
+- Authoritative source (Google's official proto definitions)
+- Complete field documentation with types and behaviors
+- Extracts enum value descriptions
+- Fast parsing (<30 seconds for all fields)
+- No network requests required
+- Works offline
+
+**Use for:**
+- Production metadata preparation
+- Complete field and enum documentation
+- Fast, reliable cache building
+
+### Web Scraping (Deprecated)
+
+**Deprecated due to:**
+- HTML structure changes breaking the scraper
+- Rate limiting and CAPTCHAs
+- Incomplete field coverage
+
+**Only use if:** You need documentation that's not in proto files (rare).
+
+---
+
+## Quick Reference
+
+```bash
+# Full rebuild from scratch (after API upgrade)
+mcc-gaql --refresh-field-cache
+mcc-gaql-gen parse-protos
+mcc-gaql-gen enrich
+mcc-gaql-gen index
+
+# Publish (repo owner only for default URL)
+mcc-gaql-gen publish
+
+# Or for custom bucket
+export MCC_GAQL_R2_ENDPOINT_URL="..."
+export MCC_GAQL_R2_BUCKET="..."
+mcc-gaql-gen publish
+```

--- a/README.md
+++ b/README.md
@@ -787,8 +787,8 @@ All configuration values can be overridden via environment variables with prefix
 | `MCC_GAQL_R2_SECRET_ACCESS_KEY` | Cloudflare R2 secret key (runtime, for publish) |
 | `MCC_GAQL_R2_BUCKET` | Cloudflare R2 bucket name (runtime, for publish) |
 | `MCC_GAQL_R2_ENDPOINT_URL` | Cloudflare R2 endpoint URL (runtime, for publish) |
-| `MCC_GAQL_R2_PUBLIC_ID` | Hashed Cloudflare R2 public bucket ID (build time, for bootstrap) |
-| `MCC_GAQL_EMBED_CLIENT_SECRET` | OAuth2 client secret for embeddings (JSON format) |
+| `MCC_GAQL_R2_PUBLIC_ID` | Hashed Cloudflare R2 public bucket ID (required at build time for mcc-gaql-gen) |
+| `MCC_GAQL_EMBED_CLIENT_SECRET` | OAuth2 client secret (JSON format, runtime alternative to clientsecret.json file) |
 | `OPENROUTER_API_KEY` | Alternative to MCC_GAQL_LLM_API_KEY |
 
 ### Example Configuration Override

--- a/README.md
+++ b/README.md
@@ -134,6 +134,31 @@ mcc-gaql --profile local-business 'SELECT
 FROM campaign'
 ```
 
+### OAuth Authentication
+
+The first time you run a query, you will be prompted to authenticate via OAuth2:
+
+**Local Browser Flow (default):**
+- A browser window will open automatically
+- Sign in with your Google account (must match the `user_email` in your config)
+- Grant permission for the app to access your Google Ads data
+- The OAuth token is cached for future use
+
+**Remote Browser Flow (`--remote-auth`):**
+If you need to authenticate on a different computer (e.g., when SSHing to a remote server):
+
+```bash
+# Use remote OAuth flow
+mcc-gaql --profile myprofile --remote-auth 'SELECT ...'
+```
+
+This will display a URL and a code. Open the URL in a browser on your local computer, sign in, and paste the authorization code back into the terminal.
+
+**Token Expiration:**
+- OAuth tokens expire every few days and you will need to re-authenticate
+- The token is cached in your config directory
+- By default, authentication is limited to email addresses explicitly whitelisted under the OAuth client account used during build
+
 ## Basic Use Cases
 
 ### Query Campaign Performance (Last 30 Days)
@@ -371,108 +396,27 @@ The natural language feature uses a **Retrieval-Augmented Generation (RAG)** app
 
 Natural language queries require an LLM provider to be configured. See [LLM Configuration](#llm-configuration-for-natural-language-queries) for detailed setup instructions.
 
-> **Warning**: This feature is **experimental**. The LLM may generate invalid GAQL queries that will result in errors when executed against the Google Ads API. Always review generated queries when possible.
-
 ### Basic Usage
 
 ```bash
 # Generate a query
 mcc-gaql-gen generate "show me all campaigns with status and bidding strategy"
 
-# Generate with local metadata
+# Generate with local metadata (if you've built your own)
 mcc-gaql-gen generate "campaign performance last 30 days including impressions, clicks, and cost" --local
 ```
 
-### mcc-gaql-gen Commands
+> **Note:** Metadata maintenance commands (`parse-protos`, `enrich`, `index`, `publish`, etc.) are documented in [METADATA_MAINTENANCE.md](METADATA_MAINTENANCE.md) for maintainers who need to rebuild metadata from source.
 
-#### parse-protos
+### Improving Generation Quality
 
-Parse Google's official proto files to extract authoritative field documentation:
+The natural language generator learns from examples in your [query cookbook](#stored-queries-file). Contributing high-quality GAQL queries improves results:
 
-```bash
-mcc-gaql-gen parse-protos [OPTIONS]
+1. **Add common queries to your cookbook** - Save queries you use frequently with descriptive names
+2. **Include varied examples** - Different resource types, filtering patterns, and date ranges help the RAG system find relevant examples
+3. **Use clear descriptions** - The description field helps match natural language prompts to appropriate query patterns
 
-OPTIONS:
-    --output <PATH>    Path to proto docs cache output (default: ~/.cache/mcc-gaql/proto_docs_v23.json)
-    --force             Force rebuild of cache even if it exists
-```
-
-**Output:** Creates `proto_docs_v23.json` with ~182 resource messages, ~360 enums, and ~3000 fields with their documentation.
-
-#### enrich
-
-Enrich field metadata with documentation:
-
-```bash
-mcc-gaql-gen enrich [OPTIONS]
-
-OPTIONS:
-    --use-proto         Use proto documentation as primary source (no LLM required)
-    --output <PATH>     Path to output enriched cache
-```
-
-Use `--use-proto` for fast enrichment using proto documentation only, without LLM API calls.
-
-#### generate
-
-Generate GAQL from natural language:
-
-```bash
-mcc-gaql-gen generate <PROMPT> [OPTIONS]
-
-ARGUMENTS:
-    <PROMPT>      Natural language query prompt
-
-OPTIONS:
-    --queries <PATH>    Path to query cookbook TOML file
-    --metadata <PATH>   Path to enriched field metadata JSON
-    --basic            Use basic RAG mode (query cookbook only)
-```
-
-```
-mcc-gaql-gen 0.16.3
-Generate GAQL queries using LLM and Google Ads metadata.
-
-USAGE:
-    mcc-gaql-gen [OPTIONS] <COMMAND>
-
-OPTIONS:
-    -v, --verbose    Enable verbose debug logging
-    -h, --help       Print help
-    -V, --version    Print version
-
-COMMANDS:
-    parse-protos    Parse proto files from googleads-rs to extract field documentation
-    enrich          Enrich field metadata with LLM-generated descriptions
-    generate        Generate a GAQL query from a natural language prompt
-    bootstrap       Download pre-built Google Ads metadata for instant GAQL generation
-    publish         Create and upload metadata bundle to R2 (ADMIN only)
-    index           Index embeddings for fast generation (pre-build local cache)
-    metadata        Display enriched field metadata for debugging
-    clear-cache     Clear the local vector cache
-    help            Print this message or the help of the given subcommand
-
-DEPRECATED COMMANDS:
-    scrape          Scraping web docs is deprecated; use parse-protos instead
-```
-
-#### parse-protos Command
-
-Parse Google's official proto files to extract authoritative field documentation:
-
-```bash
-# Parse all proto files (recommended first step)
-mcc-gaql-gen parse-protos
-
-# Force rebuild of cache
-mcc-gaql-gen parse-protos --force
-
-# Output:
-# Proto parsing complete:
-#   - 182 messages with ~3000 fields
-#   - 360 enums with ~1200 values
-# Cache saved to: ~/.cache/mcc-gaql/proto_docs_v23.json
-```
+When you generate a query, the RAG system retrieves semantically similar examples from your cookbook to guide the LLM. Better examples in your cookbook means more accurate generated queries.
 
 ### Tips for Better Results
 
@@ -494,29 +438,7 @@ mcc-gaql-gen bootstrap
 mcc-gaql-gen generate "campaign performance last 30 days"
 ```
 
-### Recommended Metadata Pipeline (Manual)
-
-For best natural language query results, prepare your metadata using this workflow:
-
-```bash
-# 1. Parse proto files (extract authoritative documentation)
-mcc-gaql-gen parse-protos
-
-# 2. Enrich field metadata cache with proto docs
-mcc-gaql-gen enrich --use-proto
-
-# 3. (Optional) Pre-build the vector cache for faster generation
-mcc-gaql-gen index
-
-# 4. Generate queries with rich context
-mcc-gaql-gen generate "campaign performance last 30 days including impressions, clicks, and cost"
-```
-
-This ensures the LLM has complete field documentation including:
-- Field descriptions from official proto files
-- Enum value meanings (e.g., `ENABLED: Campaign is serving ads`)
-- Field behavior annotations (IMMUTABLE, OUTPUT_ONLY, etc.)
-- Resource-level descriptions
+> **For maintainers:** If you need to rebuild metadata from source (e.g., after Google Ads API upgrades), see [METADATA_MAINTENANCE.md](METADATA_MAINTENANCE.md).
 
 ## CLI Reference
 
@@ -558,19 +480,6 @@ OPTIONS:
     -V, --version                      Print version information
 ```
 
-### mcc-gaql-gen (Generation Tool)
-
-#### enrich Command
-
-```bash
-mcc-gaql-gen enrich [OPTIONS]
-
-OPTIONS:
-    --use-proto                Use proto documentation as primary source (no LLM calls)
-```
-
-Use `--use-proto` to populate metadata with official proto documentation without requiring LLM API calls. This is the fastest and most reliable enrichment method.
-
 ### Common Options (mcc-gaql)
 
 | Option | Description |
@@ -600,6 +509,14 @@ Use `--use-proto` to populate metadata with official proto documentation without
 
 ### mcc-gaql-gen Commands
 
+| Command | Description |
+|---------|-------------|
+| `bootstrap` | Download pre-built metadata bundle for instant query generation |
+| `generate <prompt>` | Generate GAQL from natural language description |
+| `metadata <resource>` | Display available fields for a resource (e.g., `campaign`, `ad_group`) |
+
+> **For maintainers:** Additional commands for building metadata from source are documented in [METADATA_MAINTENANCE.md](METADATA_MAINTENANCE.md).
+
 #### bootstrap
 
 Download pre-built Google Ads metadata for instant GAQL generation. This is the quickest way to get started with natural language query generation.
@@ -608,14 +525,8 @@ Download pre-built Google Ads metadata for instant GAQL generation. This is the 
 # Download metadata bundle
 mcc-gaql-gen bootstrap
 
-# Download specific version
-mcc-gaql-gen bootstrap --version v23
-
 # Force re-download even if cache exists
 mcc-gaql-gen bootstrap --force
-
-# Verify cache without downloading
-mcc-gaql-gen bootstrap --verify-only
 ```
 
 #### generate
@@ -634,84 +545,29 @@ To validate the generated query, pipe it to `mcc-gaql --validate`:
 mcc-gaql-gen generate "show campaign performance for past week" | mcc-gaql --validate
 ```
 
-The `--validate` command automatically uses the last profile from your config. If you need to use a specific profile:
-
-```bash
-mcc-gaql-gen generate "campaign changes from last 14 days" | xargs mcc-gaql --profile myprofile --validate
-```
-
 **Options:**
-- `--profile <name>` - Profile to use for credentials (when piping to mcc-gaql)
+- `--profile <name>` - Profile to use for validation API call when default profile selected by mcc-gaql doesn't work
 - `--no-defaults` - Skip implicit default filters
-- `--use-query-cookbook` - Enable RAG search for query examples
 - `--explain` - Print explanation of the LLM selection process
-
-#### parse-protos
-
-Parse Google's official proto files to extract field documentation:
-
-```bash
-# Parse all proto files
-mcc-gaql-gen parse-protos
-
-# Force rebuild
-mcc-gaql-gen parse-protos --force
-```
-
-#### enrich
-
-Enrich field metadata with descriptions:
-
-```bash
-# Using proto documentation (fastest, no LLM calls)
-mcc-gaql-gen enrich --use-proto
-
-# Enrich specific resource
-mcc-gaql-gen enrich campaign
-```
-
-#### index
-
-Pre-build the local vector cache for faster query generation:
-
-```bash
-mcc-gaql-gen index
-```
 
 #### metadata
 
-Display enriched field metadata for debugging:
+Display enriched field metadata for a specific resource. This is useful for exploring what fields are available when writing GAQL queries.
 
 ```bash
-# Show metadata for a resource
+# Show metadata for campaign resource
 mcc-gaql-gen metadata campaign
 
-# Show all fields (not just LLM-limited subset)
+# Show all fields (not just commonly used ones)
 mcc-gaql-gen metadata campaign --show-all
-
-# Compare enriched vs non-enriched
-mcc-gaql-gen metadata campaign --diff
 ```
 
-#### clear-cache
-
-Clear the local vector cache:
-
-```bash
-mcc-gaql-gen clear-cache
-```
-
-#### publish (ADMIN only)
-
-Create and upload metadata bundle to R2 storage:
-
-```bash
-# Create and upload bundle
-mcc-gaql-gen publish
-
-# Create locally without uploading
-mcc-gaql-gen publish --dry-run
-```
+**Common resources to explore:**
+- `campaign` - Campaign fields (name, status, budget, etc.)
+- `ad_group` - Ad group fields
+- `ad_group_ad` - Ad fields including responsive search ad assets
+- `keyword_view` - Keyword performance metrics
+- `customer` - Account-level fields
 
 ## Configuration
 
@@ -808,29 +664,6 @@ export MCC_GAQL_KEEP_GOING="true"
 | `MCC_GAQL_LLM_MODEL` | Model name (e.g., `google/gemini-flash-2.0`, `gpt-4o-mini`, `hf:MiniMaxAI/MiniMax-M2.1`) | Yes |
 | `MCC_GAQL_LLM_TEMPERATURE` | Temperature for LLM generation (default: 0.1) | No |
 
-#### Multiple Models for Concurrent Processing
-
-You can specify multiple comma-separated models in `MCC_GAQL_LLM_MODEL` to enable concurrent processing during **field metadata enrichment**. When multiple models are configured, the tool uses a model pool to parallelize LLM calls, significantly speeding up the enrichment process.
-
-**How it works:**
-- Each model gets one concurrent "slot" (rate-limiting per model)
-- Batches of fields are distributed across all available models
-- If a model is busy, work is automatically routed to the next available model
-- The first model in the list is considered the "preferred" model for single-model operations
-
-**Example with multiple models:**
-```bash
-# Use multiple models concurrently for faster metadata enrichment
-export MCC_GAQL_LLM_API_KEY="your_openrouter_api_key"
-export MCC_GAQL_LLM_BASE_URL="https://openrouter.ai/api/v1"
-export MCC_GAQL_LLM_MODEL="google/gemini-flash-2.0,openai/gpt-4o-mini,anthropic/claude-3.5-haiku"
-
-# Now when you refresh the field cache, enrichment happens in parallel across all 3 models
-mcc-gaql --profile myprofile --refresh-field-cache
-```
-
-> **Note:** Multiple models are only used for field metadata enrichment operations. Natural language query generation always uses the first (preferred) model.
-
 #### Provider Examples
 
 **OpenRouter** (default):
@@ -857,7 +690,10 @@ export MCC_GAQL_LLM_MODEL="llama3.2"
 
 Using a specific model with natural language:
 ```bash
-MCC_GAQL_LLM_MODEL="hf:MiniMaxAI/MiniMax-M2.1" mcc-gaql --profile themade -n "performance from last week, including impression, clicks, prominence metrics, revenue, conversion, and all video metrics, except for trueview metrics" --format csv
+# Generate GAQL and pipe to mcc-gaql for execution
+MCC_GAQL_LLM_MODEL="hf:MiniMaxAI/MiniMax-M2.1" \
+  mcc-gaql-gen generate "performance from last week, including impression, clicks, prominence metrics, revenue, conversion, and all video metrics, except for trueview metrics" \
+  | xargs mcc-gaql --profile themade --format csv
 ```
 
 ## Stored Queries File
@@ -975,11 +811,11 @@ Configuration and data files are stored in:
 | File/Directory | Location |
 |----------------|----------|
 | Config file | `~/.config/mcc-gaql/config.toml` (Linux/macOS)<br>`%APPDATA%\mcc-gaql\config.toml` (Windows) |
-| Proto docs cache | `~/.cache/mcc-gaql/proto_docs_v23.json` |
-| Field metadata cache | `~/.config/mcc-gaql/field_metadata.json` |
+| Metadata cache | `~/.cache/mcc-gaql/field_metadata_enriched.json` |
 | LanceDB vector store | `~/.cache/mcc-gaql/lancedb/` |
-| Scraped docs cache | `~/.config/mcc-gaql/scraped_docs.json` |
 | Token cache | Same directory as config, named by user email hash |
+
+> **For maintainers:** Additional cache files (proto docs, raw metadata) are documented in [METADATA_MAINTENANCE.md](METADATA_MAINTENANCE.md).
 
 
 ## Debugging
@@ -998,128 +834,25 @@ MCC_GAQL_LOG_LEVEL="debug" mcc-gaql --profile myprofile "SELECT ..."
 
 ### Overview
 
-The `mcc-gaql-gen` tool maintains a local cache of Google Ads field metadata to support [natural language queries](#natural-language-queries-mcc-gaql-gen) and field exploration. This cache provides the LLM with knowledge of valid fields, their types, and resource relationships.
+The `mcc-gaql-gen` tool maintains a local cache of Google Ads field metadata to support [natural language queries](#natural-language-queries-mcc-gaql-gen). This cache provides the LLM with knowledge of valid fields, their types, and resource relationships.
 
-### Two Approaches to Metadata Collection
+**For users:** Download pre-built metadata with `mcc-gaql-gen bootstrap`.
 
-The tool supports two methods for extracting field documentation:
+**For maintainers:** See [METADATA_MAINTENANCE.md](METADATA_MAINTENANCE.md) for details on building metadata from source.
 
-| Approach | Status | Description |
-|----------|--------|-------------|
-| **Proto Parsing** (Recommended) | ✅ Stable | Parses Google's official proto files from `googleads-rs` crate - authoritative source |
-| **Web Scraping** | ⚠️ Deprecated | Scrapes HTML documentation from Google's developer website - unreliable |
+### Field Exploration Commands
 
-#### Proto Parsing (Recommended)
-
-The **proto parsing** approach extracts field documentation directly from Google's official protocol buffer (`.proto`) files included in the `googleads-rs` dependency. This provides authoritative,高质量 documentation straight from the source.
-
-**Advantages:**
-- Authoritative source (Google's official proto definitions)
-- Complete field documentation with types and behaviors
-- Extracts enum value descriptions
-- Fast parsing (<30 seconds for all fields)
-- No network requests required
-- Works offline
-
-**Metadata Source:** ~955 proto files bundled with `googleads-rs` at:
-```
-$CARGO_HOME/git/checkouts/googleads-rs-*/proto/google/ads/googleads/v23/
-```
-
-**Use this approach for:**
-- Production metadata preparation
-- Complete field and enum documentation
-- Fast, reliable cache building
-
-#### Web Scraping (Deprecated)
-
-The **web scraping** approach attempts to fetch documentation from Google's developer website. This is **deprecated** due to:
-- HTML structure changes breaking the scraper
-- Rate limiting and CAPTCHAs
-- Incomplete field coverage
-
-**Use this approach only if:**
-- You need documentation that's not in proto files (rare)
-- Proto parsing fails for some reason
-
-### Field Metadata Management
-
-#### Step 1: Parse Proto Files
-
-First, parse all proto files to extract documentation. This is the recommended first step:
+Display available fields for a specific resource:
 
 ```bash
-# Parse proto files from googleads-rs (takes ~30 seconds)
-mcc-gaql-gen parse-protos
-
-# Force rebuild of cache
-mcc-gaql-gen parse-protos --force
-
-# Specify custom output path
-mcc-gaql-gen parse-protos --output /custom/path/proto_docs.json
-```
-
-This creates a cache at `~/.cache/mcc-gaql/proto_docs_v23.json` containing:
-- Field documentation from ~182 resource proto files
-- Enum documentation from ~360 enum proto files
-- Field behavior annotations (IMMUTABLE, OUTPUT_ONLY, REQUIRED, OPTIONAL)
-- Type information for all fields
-
-#### Step 2: Enrich Field Metadata
-
-Merge the proto documentation into your field metadata cache:
-
-```bash
-# Using proto documentation only (no LLM required)
-mcc-gaql-gen enrich --use-proto
-
-# This populates FieldMetadata.description for all fields with proto docs
-```
-
-#### Step 3: Download Pre-built Metadata (Alternative)
-
-Instead of parsing proto files locally, you can download pre-built metadata using `bootstrap`:
-
-```bash
-mcc-gaql-gen bootstrap
-```
-
-#### Show Fields for a Resource (mcc-gaql)
-
-Display available fields for a specific resource type (e.g., campaign, ad_group, customer):
-
-```bash
-# Show all fields available for the campaign resource
+# Show fields for campaign resource
 mcc-gaql --show-fields campaign
 
 # Show fields for ad_group resource
 mcc-gaql --show-fields ad_group
 
-# Show fields for customer resource
-mcc-gaql --show-fields customer
-
-# Show fields for keyword_view resource
-mcc-gaql --show-fields keyword_view
-```
-
-#### Export Field Metadata (mcc-gaql)
-
-Export the complete field metadata summary to stdout (useful for documentation or analysis):
-
-```bash
-# Export all field metadata to a file
+# Export all field metadata
 mcc-gaql --export-field-metadata > field_metadata.txt
-
-# Export and pipe to other tools
-mcc-gaql --export-field-metadata | grep "campaign"
-```
-
-#### Publish Metadata Bundle (mcc-gaql-gen, ADMIN only)
-
-Create and upload enriched metadata bundle to Cloudflare R2 for distribution:
-
-```bash
-MCC_GAQL_R2_ACCESS_KEY_ID="your_key" MCC_GAQL_R2_SECRET_ACCESS_KEY="your_secret" mcc-gaql-gen publish
 ```
 
 ## When to Use Each Tool
@@ -1129,11 +862,11 @@ MCC_GAQL_R2_ACCESS_KEY_ID="your_key" MCC_GAQL_R2_SECRET_ACCESS_KEY="your_secret"
 | Run GAQL queries on Google Ads data | `mcc-gaql` |
 | Query multiple MCC child accounts | `mcc-gaql` |
 | Export results to CSV/JSON | `mcc-gaql` |
-| Parse proto files for metadata | `mcc-gaql-gen parse-protos` |
-| Enrich field metadata | `mcc-gaql-gen enrich --use-proto` |
 | Generate GAQL from natural language | `mcc-gaql-gen generate` |
 | Download Google Ads metadata | `mcc-gaql-gen bootstrap` |
-| Upload metadata bundle (ADMIN) | `mcc-gaql-gen publish` |
+| Explore fields supported by a resource | `mcc-gaql-gen metadata <resource>` |
+
+> **For maintainers:** Commands for building and publishing metadata (`parse-protos`, `enrich`, `publish`, etc.) are documented in [METADATA_MAINTENANCE.md](METADATA_MAINTENANCE.md).
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pre-built binaries are available for the following platforms:
 | Linux | x86_64 | `mcc-gaql-*-linux-x86_64.tar.gz` |
 | Linux | ARM64 (Graviton) | `mcc-gaql-*-linux-aarch64.tar.gz` |
 
-Download the latest release from [GitHub Releases](https://github.com/mhuang74/mcc-gaql-rs/releases/tag/v0.17.0):
+Download the latest release from [GitHub Releases](https://github.com/mhuang74/mcc-gaql-rs/releases/latest):
 
 **macOS Apple Silicon:**
 ```bash
@@ -386,7 +386,7 @@ mcc-gaql-gen generate "campaign changes from last 14 days" | xargs mcc-gaql --pr
 
 The natural language feature uses a **Retrieval-Augmented Generation (RAG)** approach:
 
-1. **Field Metadata Retrieval**: The tool retrieves relevant Google Ads field definitions from your local field cache (see [Field Metadata Management](#field-metadata-management)). This ensures the LLM knows about valid fields, their types, and which resources they belong to.
+1. **Field Metadata Retrieval**: The tool retrieves relevant Google Ads field definitions from your local field cache (see [Google Ads Field Metadata Caching](#google-ads-field-metadata-caching)). This ensures the LLM knows about valid fields, their types, and which resources they belong to.
 
 2. **Example Retrieval**: If you have a [query cookbook](#stored-queries-file) configured, semantically similar example queries are retrieved to provide additional context for the LLM.
 

--- a/crates/mcc-gaql-common/src/paths.rs
+++ b/crates/mcc-gaql-common/src/paths.rs
@@ -61,3 +61,14 @@ pub fn domain_knowledge_path() -> Result<PathBuf> {
     config_file_path("domain_knowledge.md")
         .ok_or_else(|| anyhow!("Could not determine domain knowledge path"))
 }
+
+/// Get the path to the query cookbook file
+pub fn query_cookbook_path() -> Result<PathBuf> {
+    config_file_path("query_cookbook.toml")
+        .ok_or_else(|| anyhow!("Could not determine query cookbook path"))
+}
+
+/// Get the path to proto docs cache
+pub fn proto_docs_path() -> Result<PathBuf> {
+    Ok(cache_dir()?.join("proto_docs_v23.json"))
+}

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -684,10 +684,21 @@ async fn cmd_enrich(
         .or_else(|| mcc_gaql_common::paths::field_metadata_enriched_path().ok())
         .context("Could not determine enriched metadata output path")?;
 
-    // If enriching a single resource, merge with existing enriched cache
-    if target_resource.is_some() && enriched_path.exists() {
+    // Backup existing enriched cache before modifying
+    if enriched_path.exists() {
+        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
+        let backup_path = enriched_path.with_file_name(format!(
+            "field_metadata_enriched_{}.json",
+            timestamp
+        ));
+        println!("\nBacking up existing enriched cache to {:?}...", backup_path);
+        std::fs::copy(&enriched_path, &backup_path)?;
+    }
+
+    // Merge with existing enriched cache to preserve previously enriched fields
+    if enriched_path.exists() {
         println!(
-            "\nMerging with existing enriched cache at {:?}...",
+            "Merging with existing enriched cache at {:?}...",
             enriched_path
         );
         let existing_cache = FieldMetadataCache::load_from_disk(&enriched_path).await?;
@@ -811,10 +822,21 @@ async fn cmd_enrich_proto(
         .or_else(|| mcc_gaql_common::paths::field_metadata_enriched_path().ok())
         .context("Could not determine enriched metadata output path")?;
 
-    // If enriching a single resource, merge with existing enriched cache
-    if target_resource.is_some() && enriched_path.exists() {
+    // Backup existing enriched cache before modifying
+    if enriched_path.exists() {
+        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
+        let backup_path = enriched_path.with_file_name(format!(
+            "field_metadata_enriched_{}.json",
+            timestamp
+        ));
+        println!("\nBacking up existing enriched cache to {:?}...", backup_path);
+        std::fs::copy(&enriched_path, &backup_path)?;
+    }
+
+    // Merge with existing enriched cache to preserve previously enriched fields
+    if enriched_path.exists() {
         println!(
-            "\nMerging with existing enriched cache at {:?}...",
+            "Merging with existing enriched cache at {:?}...",
             enriched_path
         );
         let existing_cache = FieldMetadataCache::load_from_disk(&enriched_path).await?;

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -576,6 +576,7 @@ async fn cmd_enrich(
                             missing_resources.len(),
                             cache.get_resources().len()
                         );
+                        println!("Missing resources: {}", missing_resources.join(", "));
                         cache.retain_resources(&missing_resources);
                     }
                     Err(e) => {
@@ -745,6 +746,7 @@ async fn cmd_enrich_proto(
                             missing_resources.len(),
                             cache.get_resources().len()
                         );
+                        println!("Missing resources: {}", missing_resources.join(", "));
                         cache.retain_resources(&missing_resources);
                     }
                     Err(e) => {

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -95,7 +95,7 @@ enum Commands {
 
     /// Enrich field metadata with LLM-generated descriptions
     Enrich {
-        /// Resource name to enrich (e.g., "campaign"). If not specified, enriches all resources.
+        /// Resource name to enrich (e.g., "campaign"). If not specified, enriches only resources missing enrichment.
         resource: Option<String>,
 
         /// Path to the field metadata cache (JSON). Defaults to the standard cache path.
@@ -133,6 +133,10 @@ enum Commands {
         /// Total concurrent LLM requests across all models (default: number of models)
         #[arg(long)]
         concurrency: Option<usize>,
+
+        /// Process all resources, even those already enriched (default: only process resources missing enrichment)
+        #[arg(long)]
+        all: bool,
     },
 
     /// Generate a GAQL query from a natural language prompt
@@ -304,6 +308,7 @@ async fn main() -> Result<()> {
             test_run,
             use_proto,
             concurrency,
+            all,
         } => {
             cmd_enrich(
                 resource,
@@ -316,6 +321,7 @@ async fn main() -> Result<()> {
                 test_run,
                 use_proto,
                 concurrency,
+                all,
             )
             .await?;
         }
@@ -465,6 +471,41 @@ async fn cmd_scrape(
     Ok(())
 }
 
+/// Check if a resource is missing enrichment in the enriched cache.
+/// A resource is considered missing enrichment if none of its fields have descriptions,
+/// or if the resource metadata lacks key_attributes/key_metrics.
+fn resource_missing_enrichment(
+    _cache: &FieldMetadataCache,
+    enriched_cache: &FieldMetadataCache,
+    resource: &str,
+) -> bool {
+    // Get fields for this resource from the enriched cache
+    let resource_fields = enriched_cache.get_resource_fields(resource);
+
+    // If no fields at all in enriched cache, definitely missing enrichment
+    if resource_fields.is_empty() {
+        return true;
+    }
+
+    // Check if any field has a description
+    let has_field_descriptions = resource_fields.iter().any(|f| {
+        f.description.as_ref().is_some_and(|d| !d.is_empty())
+    });
+
+    // Check if resource metadata has key_attributes/key_metrics
+    let has_resource_metadata = enriched_cache
+        .resource_metadata
+        .as_ref()
+        .and_then(|rm| rm.get(resource))
+        .map(|meta| {
+            !meta.key_attributes.is_empty() || !meta.key_metrics.is_empty()
+        })
+        .unwrap_or(false);
+
+    // Missing enrichment if neither field descriptions nor resource metadata exist
+    !has_field_descriptions && !has_resource_metadata
+}
+
 /// Enrich field metadata with LLM descriptions
 #[allow(clippy::too_many_arguments)]
 async fn cmd_enrich(
@@ -478,6 +519,7 @@ async fn cmd_enrich(
     test_run: bool,
     use_proto: bool,
     concurrency: Option<usize>,
+    all: bool,
 ) -> Result<()> {
     // Load metadata cache first (needed for both proto and LLM modes)
     let cache_path = metadata_cache
@@ -503,6 +545,47 @@ async fn cmd_enrich(
             cache.get_resources().len(),
             cache.fields.len()
         );
+    }
+
+    // Filter to only resources missing enrichment (unless --all flag or optional resource arg specified)
+    if !all && target_resource.is_none() && !test_run {
+        let enriched_path = output
+            .clone()
+            .or_else(|| mcc_gaql_common::paths::field_metadata_enriched_path().ok());
+
+        if let Some(ref path) = enriched_path {
+            if path.exists() {
+                println!("Loading existing enriched cache to identify resources missing enrichment...");
+                match FieldMetadataCache::load_from_disk(path).await {
+                    Ok(enriched_cache) => {
+                        let all_resources = cache.get_resources();
+                        let missing_resources: Vec<String> = all_resources
+                            .into_iter()
+                            .filter(|r| {
+                                resource_missing_enrichment(&cache, &enriched_cache, r)
+                            })
+                            .collect();
+
+                        if missing_resources.is_empty() {
+                            println!("All resources are already enriched. Use --all to re-enrich everything.");
+                            return Ok(());
+                        }
+
+                        println!(
+                            "Processing {} resources missing enrichment out of {} total resources",
+                            missing_resources.len(),
+                            cache.get_resources().len()
+                        );
+                        cache.retain_resources(&missing_resources);
+                    }
+                    Err(e) => {
+                        println!("Could not load existing enriched cache ({}). Processing all resources.", e);
+                    }
+                }
+            } else {
+                println!("No existing enriched cache found. Processing all resources.");
+            }
+        }
     }
 
     // Filter to single resource if specified
@@ -531,7 +614,7 @@ async fn cmd_enrich(
 
     // Proto-based enrichment (no LLM needed)
     if use_proto {
-        return cmd_enrich_proto(&mut cache, output, target_resource.clone()).await;
+        return cmd_enrich_proto(&mut cache, output, target_resource.clone(), all).await;
     }
 
     // LLM-based enrichment (original path)
@@ -631,7 +714,49 @@ async fn cmd_enrich_proto(
     cache: &mut FieldMetadataCache,
     output: Option<PathBuf>,
     target_resource: Option<String>,
+    all: bool,
 ) -> Result<()> {
+    // Filter to only resources missing enrichment (unless --all flag or optional resource arg specified)
+    if !all && target_resource.is_none() {
+        let enriched_path = output
+            .clone()
+            .or_else(|| mcc_gaql_common::paths::field_metadata_enriched_path().ok());
+
+        if let Some(ref path) = enriched_path {
+            if path.exists() {
+                println!("Loading existing enriched cache to identify resources missing enrichment...");
+                match FieldMetadataCache::load_from_disk(path).await {
+                    Ok(enriched_cache) => {
+                        let all_resources = cache.get_resources();
+                        let missing_resources: Vec<String> = all_resources
+                            .into_iter()
+                            .filter(|r| {
+                                resource_missing_enrichment(cache, &enriched_cache, r)
+                            })
+                            .collect();
+
+                        if missing_resources.is_empty() {
+                            println!("All resources are already enriched. Use --all to re-enrich everything.");
+                            return Ok(());
+                        }
+
+                        println!(
+                            "Processing {} resources missing enrichment out of {} total resources",
+                            missing_resources.len(),
+                            cache.get_resources().len()
+                        );
+                        cache.retain_resources(&missing_resources);
+                    }
+                    Err(e) => {
+                        println!("Could not load existing enriched cache ({}). Processing all resources.", e);
+                    }
+                }
+            } else {
+                println!("No existing enriched cache found. Processing all resources.");
+            }
+        }
+    }
+
     // Stage 1: Load or build proto docs cache
     println!("\nStage 1/2: Loading proto documentation...");
 

--- a/crates/mcc-gaql/build.rs
+++ b/crates/mcc-gaql/build.rs
@@ -1,11 +1,6 @@
-use std::env;
 use std::process::Command;
 
 fn main() {
-    // Tell cargo to rerun if these environment variables change
-    println!("cargo:rerun-if-env-changed=MCC_GAQL_EMBED_CLIENT_SECRET");
-    println!("cargo:rerun-if-env-changed=MCC_GAQL_DEV_TOKEN");
-
     // Get the git hash for version info
     let git_hash = get_git_hash();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
@@ -16,42 +11,12 @@ fn main() {
     let build_time = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
     println!("cargo:rustc-env=BUILD_TIME={}", build_time);
 
-    // Handle client secret embedding
-    if let Ok(client_secret_json) = env::var("MCC_GAQL_EMBED_CLIENT_SECRET") {
-        println!(
-            "cargo:warning=Embedding OAuth2 credentials from MCC_GAQL_EMBED_CLIENT_SECRET environment variable"
-        );
-        println!(
-            "cargo:rustc-env=MCC_GAQL_EMBED_CLIENT_SECRET={}",
-            client_secret_json
-        );
-    } else {
-        println!("cargo:warning=MCC_GAQL_EMBED_CLIENT_SECRET environment variable not set");
-        println!(
-            "cargo:warning=Binary will require clientsecret.json in config directory at runtime"
-        );
-        println!(
-            "cargo:warning=To embed credentials: set MCC_GAQL_EMBED_CLIENT_SECRET during build"
-        );
-        println!(
-            "cargo:warning=Example: MCC_GAQL_EMBED_CLIENT_SECRET=\"$(cat clientsecret.json)\" cargo build --release"
-        );
-    }
-
-    // Handle developer token embedding
-    if let Ok(dev_token) = env::var("MCC_GAQL_DEV_TOKEN") {
-        println!(
-            "cargo:warning=Embedding Google Ads Developer Token from MCC_GAQL_DEV_TOKEN environment variable"
-        );
-        println!("cargo:rustc-env=MCC_GAQL_DEV_TOKEN={}", dev_token);
-    } else {
-        println!("cargo:warning=MCC_GAQL_DEV_TOKEN environment variable not set");
-        println!(
-            "cargo:warning=Binary will require dev_token in config file or MCC_GAQL_DEV_TOKEN env var at runtime"
-        );
-        println!("cargo:warning=To embed dev token: set MCC_GAQL_DEV_TOKEN during build");
-        println!("cargo:warning=Example: MCC_GAQL_DEV_TOKEN=\"your-token\" cargo build --release");
-    }
+    // Note: MCC_GAQL_DEV_TOKEN and MCC_GAQL_EMBED_CLIENT_SECRET are intentionally
+    // NOT embedded at build time to avoid leaking secrets in the binary.
+    // These must be provided at runtime via:
+    // - Environment variables (MCC_GAQL_DEV_TOKEN, MCC_GAQL_EMBED_CLIENT_SECRET)
+    // - Config file (dev_token field)
+    // - clientsecret.json file in config directory
 }
 
 /// Get the short git hash, with optional -dirty suffix

--- a/crates/mcc-gaql/src/config.rs
+++ b/crates/mcc-gaql/src/config.rs
@@ -358,6 +358,19 @@ fn display_profile_config(profile: &str) -> anyhow::Result<()> {
 }
 
 /// Display configuration in a human-readable format
+/// Helper function to display path with existence status
+fn show_path_status(label: &str, path_result: &anyhow::Result<std::path::PathBuf>) {
+    match path_result {
+        Ok(path) => {
+            let status = if path.exists() { "exists" } else { "not found" };
+            println!("  {}: {} ({})", label, path.display(), status);
+        }
+        Err(_) => {
+            println!("  {}: <unable to determine>", label);
+        }
+    }
+}
+
 pub fn display_config(profile_name: Option<&str>) -> anyhow::Result<()> {
     println!("Configuration Details");
     println!("====================");
@@ -376,15 +389,85 @@ pub fn display_config(profile_name: Option<&str>) -> anyhow::Result<()> {
     }
     println!();
 
+    // Show file locations
+    println!("File Locations:");
+    println!("---------------");
+
+    // Config directory files
+    show_path_status("Config directory", &mcc_gaql_common::paths::config_dir());
+    show_path_status("Query cookbook", &mcc_gaql_common::paths::query_cookbook_path());
+    show_path_status("Domain knowledge", &mcc_gaql_common::paths::domain_knowledge_path());
+
+    // Cache directory files
+    show_path_status("Cache directory", &mcc_gaql_common::paths::cache_dir());
+    show_path_status("Field metadata", &mcc_gaql_common::paths::field_metadata_cache_path());
+    show_path_status("Field metadata (enriched)", &mcc_gaql_common::paths::field_metadata_enriched_path());
+    show_path_status("Proto docs", &mcc_gaql_common::paths::proto_docs_path());
+    show_path_status("LanceDB", &mcc_gaql_common::paths::lancedb_path());
+
+    println!();
+
+    // Show environment variable overrides
+    println!("Environment Variable Overrides:");
+    println!("  Prefix: {}", ENV_VAR_PREFIX);
+
+    let env_vars = [
+        // Configuration fields
+        "MCC_ID",
+        "USER_EMAIL",
+        "CUSTOMER_ID",
+        "FORMAT",
+        "KEEP_GOING",
+        "TOKEN_CACHE_FILENAME",
+        "CUSTOMERIDS_FILENAME",
+        "QUERIES_FILENAME",
+        "DEV_TOKEN",
+        "FIELD_METADATA_CACHE",
+        "FIELD_METADATA_TTL_DAYS",
+        "EMBED_CLIENT_SECRET",
+        // LLM configuration
+        "LLM_API_KEY",
+        "LLM_BASE_URL",
+        "LLM_MODEL",
+        "LLM_TEMPERATURE",
+        // R2 storage configuration
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+        "R2_BUCKET",
+        "R2_ENDPOINT_URL",
+        "R2_PUBLIC_ID",
+        // Logging
+        "LOG_LEVEL",
+    ];
+
+    let mut found_any = false;
+    for var in &env_vars {
+        let full_var = format!("{}{}", ENV_VAR_PREFIX, var);
+        if let Ok(value) = std::env::var(&full_var) {
+            println!("  {}: {}", full_var, value);
+            found_any = true;
+        }
+    }
+
+    if !found_any {
+        println!("  (none set)");
+    }
+
+    println!();
+
     // Show profile information
     if let Some(profile) = profile_name {
-        println!("Profile: {}", profile);
+        println!("Profile:");
+        println!("========");
+        println!("{}", profile);
         println!();
         display_profile_config(profile)?;
     } else {
         match list_profiles() {
             Ok(profiles) if !profiles.is_empty() => {
-                println!("Profiles: {} found", profiles.len());
+                println!("Profiles:");
+                println!("=========");
+                println!("{} found", profiles.len());
                 println!();
 
                 for (idx, profile) in profiles.iter().enumerate() {
@@ -399,40 +482,20 @@ pub fn display_config(profile_name: Option<&str>) -> anyhow::Result<()> {
                 }
             }
             Ok(_) => {
-                println!("Profiles: (none found)");
+                println!("Profiles:");
+                println!("=========");
+                println!("(none found)");
                 println!();
                 println!("No profiles configured in config file.");
                 println!("Run 'mcc-gaql --setup' to create a new profile.");
             }
             Err(e) => {
-                println!("Profiles: Error reading config file");
+                println!("Profiles:");
+                println!("=========");
+                println!("Error reading config file");
                 println!("  Error: {}", e);
             }
         }
-    }
-
-    println!();
-    println!("Environment Variable Overrides:");
-    println!("  Prefix: {}", ENV_VAR_PREFIX);
-
-    let env_vars = [
-        "EMBED_CLIENT_SECRET",
-        "DEV_TOKEN",
-        "LOG_LEVEL",
-        "QUERIES_FILENAME",
-    ];
-
-    let mut found_any = false;
-    for var in &env_vars {
-        let full_var = format!("{}{}", ENV_VAR_PREFIX, var);
-        if let Ok(value) = std::env::var(&full_var) {
-            println!("  {}: {}", full_var, value);
-            found_any = true;
-        }
-    }
-
-    if !found_any {
-        println!("  (none set)");
     }
 
     Ok(())

--- a/crates/mcc-gaql/src/googleads.rs
+++ b/crates/mcc-gaql/src/googleads.rs
@@ -59,15 +59,13 @@ const ENDPOINT: &str = "https://googleads.googleapis.com:443";
 // Developer Token configuration with priority order:
 // 1. Config: Pass via dev_token parameter (from config file)
 // 2. Runtime: Check MCC_GAQL_DEV_TOKEN env var at runtime
-// 3. Compile-time: Set MCC_GAQL_DEV_TOKEN env var during build
-const EMBEDDED_DEV_TOKEN: Option<&str> = option_env!("MCC_GAQL_DEV_TOKEN");
 
 const FILENAME_CLIENT_SECRET: &str = "clientsecret.json";
 static GOOGLE_ADS_API_SCOPE: &str = "https://www.googleapis.com/auth/adwords";
 
-// Embed the client secret at compile time if the file exists
-#[cfg(not(feature = "external_client_secret"))]
-const EMBEDDED_CLIENT_SECRET: Option<&str> = option_env!("MCC_GAQL_EMBED_CLIENT_SECRET");
+// Client secret configuration with priority order:
+// 1. Runtime: Check MCC_GAQL_EMBED_CLIENT_SECRET env var at runtime
+// 2. File: Load from clientsecret.json in config directory
 
 // incomplete. Only what I need for the moment.
 const GOOGLE_ADS_METRICS_INTEGER_FIELDS: &[&str] = &[
@@ -155,7 +153,6 @@ pub fn generate_token_cache_filename(user_email: &str) -> String {
 /// Get developer token with priority order:
 /// 1. Provided parameter (from config file)
 /// 2. Runtime environment variable MCC_GAQL_DEV_TOKEN
-/// 3. Compile-time embedded token
 fn get_dev_token(config_token: Option<&str>) -> Result<String> {
     if let Some(token) = config_token {
         log::debug!("Using developer token from config");
@@ -167,35 +164,31 @@ fn get_dev_token(config_token: Option<&str>) -> Result<String> {
         return Ok(token);
     }
 
-    if let Some(token) = EMBEDDED_DEV_TOKEN {
-        log::debug!("Using developer token embedded at compile time");
-        return Ok(token.to_string());
-    }
-
     bail!(
         "Google Ads Developer Token required but not found. Provide via:\n  \
          1. Config file: Add 'dev_token = \"YOUR_TOKEN\"' to your profile\n  \
-         2. Runtime env: export MCC_GAQL_DEV_TOKEN=\"YOUR_TOKEN\"\n  \
-         3. Build time: MCC_GAQL_DEV_TOKEN=\"YOUR_TOKEN\" cargo build\n\n  \
+         2. Runtime env: export MCC_GAQL_DEV_TOKEN=\"YOUR_TOKEN\"\n\n  \
          Get your developer token at:\n  \
          https://developers.google.com/google-ads/api/docs/get-started/dev-token"
     )
 }
 
-/// Get client secret from embedded or file
+/// Get client secret from runtime env var or file
 async fn get_client_secret() -> Result<ApplicationSecret> {
     #[cfg(not(feature = "external_client_secret"))]
-    let app_secret: ApplicationSecret = if let Some(embedded_json) = EMBEDDED_CLIENT_SECRET {
-        log::debug!("Using embedded client secret");
-        yup_oauth2::parse_application_secret(embedded_json)
-            .context("Failed to parse embedded client secret")?
+    let app_secret: ApplicationSecret = if let Ok(runtime_json) =
+        std::env::var("MCC_GAQL_EMBED_CLIENT_SECRET")
+    {
+        log::debug!("Using client secret from runtime environment variable");
+        yup_oauth2::parse_application_secret(&runtime_json)
+            .context("Failed to parse client secret from MCC_GAQL_EMBED_CLIENT_SECRET env var")?
     } else {
-        log::debug!("No embedded client secret found, loading from file");
+        log::debug!("Loading client secret from file");
         let client_secret_path = config_file_path(FILENAME_CLIENT_SECRET)
             .context("Failed to determine client secret path")?;
         yup_oauth2::read_application_secret(client_secret_path.as_path())
             .await
-            .context("clientsecret.json file not found and no embedded secret available")?
+            .context("clientsecret.json file not found. Provide via MCC_GAQL_EMBED_CLIENT_SECRET env var or place clientsecret.json in config directory")?
     };
 
     #[cfg(feature = "external_client_secret")]

--- a/crates/mcc-gaql/src/setup.rs
+++ b/crates/mcc-gaql/src/setup.rs
@@ -160,22 +160,17 @@ pub fn run_wizard() -> Result<()> {
     println!();
     println!("Next steps:");
 
-    #[cfg(not(feature = "external_client_secret"))]
-    let has_embedded_secret = option_env!("MCC_GAQL_EMBED_CLIENT_SECRET").is_some();
+    // Check if client secret is available via runtime env var
+    let has_runtime_secret = std::env::var("MCC_GAQL_EMBED_CLIENT_SECRET").is_ok();
 
-    #[cfg(feature = "external_client_secret")]
-    let has_embedded_secret = false;
-
-    if has_embedded_secret {
-        println!(
-            "  1. OAuth2 credentials are embedded in this binary (no clientsecret.json needed)"
-        );
+    if has_runtime_secret {
+        println!("  1. OAuth2 credentials found in MCC_GAQL_EMBED_CLIENT_SECRET environment variable");
     } else {
         println!(
             "  1. Place your OAuth2 credentials in: {:?}",
             config_file_path("clientsecret.json")
         );
-        println!("     (Or rebuild with credentials embedded - see README for details)");
+        println!("     (Or set MCC_GAQL_EMBED_CLIENT_SECRET environment variable)");
     }
 
     if config.customerids_filename.is_some() {

--- a/docs/DEV_TOKEN_CHANGES.md
+++ b/docs/DEV_TOKEN_CHANGES.md
@@ -1,5 +1,7 @@
 # Developer Token Configuration - Implementation Changes
 
+> **⚠️ OUTDATED**: This document describes an older implementation. As of the latest version, `MCC_GAQL_DEV_TOKEN` and `MCC_GAQL_EMBED_CLIENT_SECRET` are **NOT** embedded at build time for security reasons. See [DEV_TOKEN_CONFIGURATION.md](DEV_TOKEN_CONFIGURATION.md) for current documentation.
+
 ## Summary
 
 Implemented flexible, required configuration for Google Ads Developer Token. **No fallback token** - users must provide their own token via one of three methods.

--- a/docs/DEV_TOKEN_CONFIGURATION.md
+++ b/docs/DEV_TOKEN_CONFIGURATION.md
@@ -12,7 +12,6 @@ The tool checks for the developer token in the following priority order:
 
 1. **Config File** (highest priority) - Per-profile configuration
 2. **Runtime Environment Variable** - `MCC_GAQL_DEV_TOKEN`
-3. **Compile-time Embedded** - Set during `cargo build`
 
 If no token is found from any source, the tool will exit with an error message.
 
@@ -64,26 +63,6 @@ MCC_GAQL_DEV_TOKEN="YOUR_TOKEN" mcc-gaql --profile myprofile "SELECT ..."
 - Temporarily overriding config
 - CI/CD environments
 
-### 3. Compile-time Embedding
-
-Embed the token at build time:
-
-```bash
-MCC_GAQL_DEV_TOKEN="YOUR_TOKEN" cargo build --release
-```
-
-The token will be compiled into the binary.
-
-**Advantages:**
-- No external configuration needed
-- Single standalone binary
-
-**Use when:**
-- Distributing binaries to users
-- All users share the same Google Ads application
-- Simplifying deployment
-
-**Security Note:** The embedded token is visible to anyone who can inspect the binary (e.g., via `strings`). Only embed tokens for applications where you control distribution or where the token is already considered semi-public.
 
 ## Getting Your Developer Token
 
@@ -137,20 +116,6 @@ mcc-gaql --profile myprofile "SELECT ..."
 MCC_GAQL_DEV_TOKEN="TEST_TOKEN" mcc-gaql --profile myprofile "SELECT ..."
 ```
 
-### Example 3: Embedded Token for Distribution
-
-Building a binary for distribution:
-
-```bash
-# Build with embedded token
-MCC_GAQL_DEV_TOKEN="YOUR_PRODUCTION_TOKEN" cargo build --release
-
-# Distribute the binary
-cp target/release/mcc-gaql /usr/local/bin/
-
-# Users can run without configuration
-mcc-gaql --user-email user@example.com --customer-id 123-456-7890 "SELECT ..."
-```
 
 ## Verifying Your Configuration
 
@@ -160,7 +125,7 @@ To see which token source is being used, enable debug logging:
 MCC_GAQL_LOG_LEVEL="info,mcc_gaql=debug" mcc-gaql --profile myprofile "SELECT ..."
 ```
 
-Look for one of these messages:
+Look for these messages:
 
 - `"Using developer token from config"` - Config file token
 - `"Using developer token from runtime environment variable"` - `MCC_GAQL_DEV_TOKEN` env var
@@ -206,7 +171,6 @@ Your token hasn't been approved by Google yet. This can take a few days. Meanwhi
 The tool cannot find a developer token. Provide one via:
 1. Add to config file: `dev_token = "YOUR_TOKEN"`
 2. Set environment variable: `export MCC_GAQL_DEV_TOKEN="YOUR_TOKEN"`
-3. Embed at build time: `MCC_GAQL_DEV_TOKEN="YOUR_TOKEN" cargo build`
 
 ### "Rate limit exceeded"
 
@@ -237,10 +201,9 @@ MCC_GAQL_LOG_LEVEL="debug" mcc-gaql --profile myprofile "SELECT ..."
 1. **Development**: Use config file or environment variable for flexibility
 2. **Testing**: Use environment variable for easy token switching
 3. **Production**: Use config file with proper file permissions
-4. **Distribution**: Use compile-time embedding for standalone binaries
-5. **Multi-tenant**: Use per-profile tokens in config file
-6. **CI/CD**: Use environment variables or secrets management
-7. **Never**: Don't commit tokens to version control
-8. **Rotate**: Periodically rotate developer tokens
-9. **Monitor**: Set up alerts for API quota usage
-10. **Document**: Keep track of which token belongs to which account
+4. **Multi-tenant**: Use per-profile tokens in config file
+5. **CI/CD**: Use environment variables or secrets management
+6. **Never**: Don't commit tokens to version control
+7. **Rotate**: Periodically rotate developer tokens
+8. **Monitor**: Set up alerts for API quota usage
+9. **Document**: Keep track of which token belongs to which account

--- a/docs/EMBEDDING_CREDENTIALS.md
+++ b/docs/EMBEDDING_CREDENTIALS.md
@@ -1,5 +1,13 @@
 # Embedding OAuth2 Credentials in the Binary
 
+> **⚠️ DEPRECATED**: As of the latest version, credentials are **NO LONGER** embedded at build time for security reasons. This document is kept for historical reference only.
+>
+> **Current approach:** Credentials must be provided at runtime via:
+> - Environment variable `MCC_GAQL_EMBED_CLIENT_SECRET`
+> - File `clientsecret.json` in config directory
+>
+> See [DEV_TOKEN_CONFIGURATION.md](DEV_TOKEN_CONFIGURATION.md) for current documentation.
+
 ## Overview
 
 Your `clientsecret.json` file can now be safely embedded into the binary at compile time, eliminating the need to distribute it separately. This makes tool distribution much more convenient.

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,7 @@
 # Developer Token Configuration - Implementation Summary
 
+> **⚠️ OUTDATED**: This document describes an older implementation. As of the latest version, `MCC_GAQL_DEV_TOKEN` and `MCC_GAQL_EMBED_CLIENT_SECRET` are **NOT** embedded at build time for security reasons. See [DEV_TOKEN_CONFIGURATION.md](DEV_TOKEN_CONFIGURATION.md) for current documentation.
+
 ## Overview
 
 Implemented flexible configuration for Google Ads Developer Token with multiple sources and priority-based resolution.

--- a/specs/only_enrich_missing_resources_by_default.md
+++ b/specs/only_enrich_missing_resources_by_default.md
@@ -1,0 +1,244 @@
+# Plan: Enhance Enrich Command for API Upgrades
+
+## Context
+
+When Google Ads API upgrades happen (e.g., v23.1 → v23.2), new resources are added that don't have enrichment data. Currently, the `mcc-gaql-gen enrich` command processes **all** resources by default, which is wasteful when only a few new resources need enrichment. The user wants:
+
+1. **Default behavior change**: When no resource argument is specified, only process resources **missing enrichment** (i.e., resources with no enriched fields or empty key_attributes/key_metrics)
+2. **New `--all` flag**: Force processing all resources (current default behavior)
+
+A resource is considered "missing enrichment" if `mcc-gaql-gen metadata <resource> --show-all` returns no results (i.e., no fields have descriptions).
+
+## Current Behavior Analysis
+
+**File**: `crates/mcc-gaql-gen/src/main.rs`
+
+The `Enrich` command (lines 96-136) currently:
+- Takes an optional `resource` argument to process a single resource
+- Has `--test-run` to limit to test resources
+- By default (no `resource` arg), processes **all** resources from the cache
+
+The `cmd_enrich` function (lines 470-627):
+- Loads field metadata cache
+- Filters to single resource if `target_resource` is Some
+- Calls `enricher.enrich(&mut cache, &scraped).await` to process all fields in the cache
+
+## Implementation Plan
+
+### Step 1: Add `--all` CLI Option
+
+**File**: `crates/mcc-gaql-gen/src/main.rs:96-136`
+
+Add a new boolean flag `--all` to the `Enrich` command:
+
+```rust
+/// Enrich field metadata with LLM-generated descriptions
+Enrich {
+    /// Resource name to enrich (e.g., "campaign"). If not specified, enriches only resources missing enrichment.
+    resource: Option<String>,
+
+    // ... existing options ...
+
+    /// Process all resources, even those already enriched (default: only process resources missing enrichment)
+    #[arg(long)]
+    all: bool,
+},
+```
+
+Update the doc comment for `resource` to reflect the new default behavior.
+
+### Step 2: Modify `cmd_enrich` Signature and Logic
+
+**File**: `crates/mcc-gaql-gen/src/main.rs:470-500`
+
+Add `all: bool` parameter to `cmd_enrich` function signature.
+
+After loading the cache and handling `--test-run`, add logic to filter to resources missing enrichment:
+
+1. If `all` is false AND `resource` is None AND `test_run` is false:
+   - Load existing enriched cache if it exists
+   - Identify resources that are missing enrichment
+   - Filter the cache to only those resources
+   - Print info message about which resources are being processed
+
+**Helper function to identify missing enrichment**:
+
+```rust
+/// Check if a resource is missing enrichment in the enriched cache.
+/// A resource is considered missing enrichment if none of its fields have descriptions,
+/// or if the resource metadata lacks key_attributes/key_metrics.
+fn resource_missing_enrichment(
+    cache: &FieldMetadataCache,
+    enriched_cache: &FieldMetadataCache,
+    resource: &str,
+) -> bool {
+    // Get fields for this resource from the enriched cache
+    let resource_fields = enriched_cache.get_resource_fields(resource);
+
+    // If no fields at all in enriched cache, definitely missing enrichment
+    if resource_fields.is_empty() {
+        return true;
+    }
+
+    // Check if any field has a description
+    let has_field_descriptions = resource_fields.iter().any(|f| {
+        f.description.as_ref().is_some_and(|d| !d.is_empty())
+    });
+
+    // Check if resource metadata has key_attributes/key_metrics
+    let has_resource_metadata = enriched_cache
+        .resource_metadata
+        .as_ref()
+        .and_then(|rm| rm.get(resource))
+        .map(|meta| {
+            !meta.key_attributes.is_empty() || !meta.key_metrics.is_empty()
+        })
+        .unwrap_or(false);
+
+    // Missing enrichment if neither field descriptions nor resource metadata exist
+    !has_field_descriptions && !has_resource_metadata
+}
+```
+
+### Step 3: Filter Resources Before Enrichment
+
+**File**: `crates/mcc-gaql-gen/src/main.rs:493-530`
+
+Insert the filtering logic after handling `--test-run`:
+
+```rust
+// Filter to only resources missing enrichment (unless --all flag or optional resource arg specified)
+if !all && target_resource.is_none() && !test_run {
+    let enriched_path = output
+        .clone()
+        .or_else(|| mcc_gaql_common::paths::field_metadata_enriched_path().ok());
+
+    if let Some(ref path) = enriched_path {
+        if path.exists() {
+            println!("Loading existing enriched cache to identify resources missing enrichment...");
+            match FieldMetadataCache::load_from_disk(path).await {
+                Ok(enriched_cache) => {
+                    let all_resources = cache.get_resources();
+                    let missing_resources: Vec<String> = all_resources
+                        .into_iter()
+                        .filter(|r| {
+                            resource_missing_enrichment(&cache, &enriched_cache, r)
+                        })
+                        .collect();
+
+                    if missing_resources.is_empty() {
+                        println!("All resources are already enriched. Use --all to re-enrich everything.");
+                        return Ok(());
+                    }
+
+                    println!(
+                        "Processing {} resources missing enrichment out of {} total resources",
+                        missing_resources.len(),
+                        cache.get_resources().len()
+                    );
+                    cache.retain_resources(&missing_resources);
+                }
+                Err(e) => {
+                    println!("Could not load existing enriched cache ({}). Processing all resources.", e);
+                }
+            }
+        } else {
+            println!("No existing enriched cache found. Processing all resources.");
+        }
+    }
+}
+```
+
+### Step 4: Update `cmd_enrich` Call Site
+
+**File**: `crates/mcc-gaql-gen/src/main.rs:296-321`
+
+Find where the `Enrich` command is dispatched and add the `all` argument:
+
+```rust
+Commands::Enrich {
+    resource,
+    metadata_cache,
+    output,
+    scraped_docs,
+    batch_size,
+    scrape_delay_ms,
+    scrape_ttl_days,
+    test_run,
+    use_proto,
+    concurrency,
+    all,  // NEW
+} => {
+    cmd_enrich(
+        resource,
+        metadata_cache,
+        output,
+        scraped_docs,
+        batch_size,
+        scrape_delay_ms,
+        scrape_ttl_days,
+        test_run,
+        use_proto,
+        concurrency,
+        all,  // NEW
+    )
+    .await
+}
+```
+
+### Step 5: Update Proto-based Enrichment Path
+
+**File**: `crates/mcc-gaql-gen/src/main.rs:630-710`
+
+The `cmd_enrich_proto` function also needs to handle the `--all` flag for consistency. However, proto-based enrichment is fast (no LLM calls), so the benefit is less pronounced. For simplicity, we can:
+
+1. Pass `all` to `cmd_enrich_proto`
+2. Apply the same filtering logic
+
+Or alternatively, note that proto-based enrichment doesn't need this feature as much since it's fast. For this implementation, apply the same filtering to both paths for consistency.
+
+## Files to Modify
+
+1. **`crates/mcc-gaql-gen/src/main.rs`**
+   - Add `all: bool` field to `Enrich` command (line ~136)
+   - Update doc comment for `resource` field
+   - Add `resource_missing_enrichment` helper function (after line 470)
+   - Add filtering logic in `cmd_enrich` (after line 493)
+   - Update `cmd_enrich` signature and call site (line ~350, line ~470)
+
+## Testing Plan
+
+1. **Test with existing enriched cache**:
+   ```bash
+   # Should only process resources missing enrichment
+   cargo run -p mcc-gaql-gen -- enrich
+
+   # Should process all resources (old behavior)
+   cargo run -p mcc-gaql-gen -- enrich --all
+
+   # Should process only specified resource (unchanged)
+   cargo run -p mcc-gaql-gen -- enrich campaign
+   ```
+
+2. **Test with no enriched cache**:
+   ```bash
+   # Temporarily move enriched cache away
+   mv ~/Library/Caches/mcc-gaql/field_metadata_enriched.json ~/Library/Caches/mcc-gaql/field_metadata_enriched.json.bak
+
+   # Should process all resources (no cache to compare against)
+   cargo run -p mcc-gaql-gen -- enrich
+
+   # Restore cache
+   mv ~/Library/Caches/mcc-gaql/field_metadata_enriched.json.bak ~/Library/Caches/mcc-gaql/field_metadata_enriched.json
+   ```
+
+3. **Test with new resource** (simulated):
+   ```bash
+   # After adding a new resource to metadata but not enriched cache
+   # Should only process that new resource
+   cargo run -p mcc-gaql-gen -- enrich
+   ```
+
+## Backward Compatibility Note
+
+This is a **behavior change** for the default case. Users who previously ran `mcc-gaql-gen enrich` without arguments to process all resources will now need to add `--all` to get the same behavior. This is intentional per the user's requirement.


### PR DESCRIPTION
## Summary

- Default behavior change: `mcc-gaql-gen enrich` now only processes resources missing enrichment (no field descriptions or empty key_attributes/metrics)
- New `--all` flag: Forces processing all resources (old default behavior)
- Prints list of missing resources before enrichment starts
- Separate metadata documentation for users vs maintainers
- Version bump

## Motivation

When Google Ads API upgrades happen (e.g., v23.1 → v23.2), new resources are added that don't have enrichment data. Previously, the `enrich` command processed **all** resources by default, which was wasteful when only a few new resources needed enrichment.

## Changes

### Core Feature (`d92b887`, `f7ba1aa`)

- **New default**: Only enriches resources missing enrichment
- **New `--all` flag**: Re-enriches all resources (old behavior)
- **Helper function**: `resource_missing_enrichment()` checks if a resource has no enriched fields or empty key_attributes/key_metrics
- **Enhanced output**: Shows which specific resources are being processed

**Files modified**: `crates/mcc-gaql-gen/src/main.rs`

### Documentation (`285d69f`)

- Separated `README.md` into user-facing documentation
- Created `METADATA_MAINTENANCE.md` for maintainer documentation
- Improved release platform documentation

**Files modified**: `README.md`, `METADATA_MAINTENANCE.md`

### Version & Specs (`420a335`)

- Bumped version to v0.17.0
- Added spec file for enrichment feature design decisions

**Files modified**: `Cargo.toml`, `Cargo.lock`
**Files added**: `specs/only_enrich_missing_resources_by_default.md`

## Usage

```bash
# NEW: Only process resources missing enrichment
mcc-gaql-gen enrich

# NEW: Process all resources (old default)
mcc-gaql-gen enrich --all

# UNCHANGED: Process specific resource
mcc-gaql-gen enrich campaign
```

## Backward Compatibility

This is a **behavior change** for the default case. Users who previously ran `mcc-gaql-gen enrich` without arguments to process all resources will now need to add `--all` to get the same behavior. This is intentional for the API upgrade workflow.