### PR TITLE
feat(rag): display segment categories in Phase 1 resource descriptions

### DIFF
--- a/crates/mcc-gaql-common/src/field_metadata.rs
+++ b/crates/mcc-gaql-common/src/field_metadata.rs
@@ -139,7 +139,9 @@ impl ResourceMetadata {
     /// Returns true if this resource supports metrics (performance data).
     /// Derived from selectable_with: any field starting with "metrics." indicates metrics support.
     pub fn has_metrics(&self) -> bool {
-        self.selectable_with.iter().any(|f| f.starts_with("metrics."))
+        self.selectable_with
+            .iter()
+            .any(|f| f.starts_with("metrics."))
     }
 }
 
@@ -339,9 +341,10 @@ impl FieldMetadataCache {
         self.fields.retain(|_, field| {
             // Keep if field belongs to a retained resource (e.g., "keyword_view.resource_name")
             if let Some(r) = field.get_resource()
-                && keep_set.contains(&r) {
-                    return true;
-                }
+                && keep_set.contains(&r)
+            {
+                return true;
+            }
 
             // Keep RESOURCE-category fields whose name matches a kept resource (e.g., "keyword_view")
             if field.is_resource() && keep_set.contains(&field.name) {
@@ -524,7 +527,10 @@ impl FieldMetadataCache {
                 output.push_str(&format!("Key metrics: {}\n", key_metrics.join(", ")));
             }
             if !identity_fields.is_empty() {
-                output.push_str(&format!("Identity fields: {}\n", identity_fields.join(", ")));
+                output.push_str(&format!(
+                    "Identity fields: {}\n",
+                    identity_fields.join(", ")
+                ));
             }
 
             output.push('\n');
@@ -554,11 +560,10 @@ impl FieldMetadataCache {
                 .resource_metadata
                 .as_mut()
                 .and_then(|m| m.get_mut(resource))
+                && rm.identity_fields.is_empty()
             {
-                if rm.identity_fields.is_empty() {
-                    rm.identity_fields = identity;
-                    count += 1;
-                }
+                rm.identity_fields = identity;
+                count += 1;
             }
         }
         count
@@ -779,7 +784,11 @@ const RESOURCE_HIERARCHY: &[(&str, Option<&str>, &[&str])] = &[
         Some("campaign"),
         &["campaign_criterion.criterion_id"],
     ),
-    ("ad_group", Some("campaign"), &["ad_group.id", "ad_group.name"]),
+    (
+        "ad_group",
+        Some("campaign"),
+        &["ad_group.id", "ad_group.name"],
+    ),
     (
         "ad_group_ad",
         Some("ad_group"),
@@ -816,11 +825,7 @@ const RESOURCE_HIERARCHY: &[(&str, Option<&str>, &[&str])] = &[
         Some("campaign"),
         &["asset.id", "asset.name"],
     ),
-    (
-        "change_event",
-        Some("campaign"),
-        &[],
-    ),
+    ("change_event", Some("campaign"), &[]),
 ];
 
 /// Walk the resource hierarchy chain from `resource` up to the root (customer inclusive).
@@ -831,16 +836,11 @@ fn get_hierarchy_chain(resource: &str) -> Vec<&'static str> {
     let mut current = resource;
 
     // Walk up by finding the parent of each resource
-    loop {
-        if let Some(&(name, parent, _)) = RESOURCE_HIERARCHY.iter().find(|(n, _, _)| *n == current) {
-            chain.push(name);
-            match parent {
-                Some(p) => current = p,
-                None => break,
-            }
-        } else {
-            // Unmapped resource: just add it and stop (customer.id will be handled by heuristic)
-            break;
+    while let Some(&(name, parent, _)) = RESOURCE_HIERARCHY.iter().find(|(n, _, _)| *n == current) {
+        chain.push(name);
+        match parent {
+            Some(p) => current = p,
+            None => break,
         }
     }
     chain.reverse();
@@ -1745,11 +1745,17 @@ mod tests {
             .unwrap()
             .get("campaign")
             .unwrap();
-        assert!(!rm.identity_fields.is_empty(), "campaign identity_fields should be populated");
+        assert!(
+            !rm.identity_fields.is_empty(),
+            "campaign identity_fields should be populated"
+        );
         assert!(rm.identity_fields.contains(&"customer.id".to_string()));
         assert!(rm.identity_fields.contains(&"campaign.id".to_string()));
         assert!(rm.identity_fields.contains(&"campaign.name".to_string()));
-        assert!(rm.identity_fields.contains(&"campaign.advertising_channel_type".to_string()));
+        assert!(
+            rm.identity_fields
+                .contains(&"campaign.advertising_channel_type".to_string())
+        );
 
         // customer identity_fields should be untouched
         let rm_cust = cache
@@ -1810,11 +1816,26 @@ mod tests {
         let fields = build_test_run_fields();
         // Realistic: campaign's selectable_with does NOT include campaign's own fields
         let result = compute_identity_fields("campaign", &fields, &[]);
-        assert!(result.contains(&"customer.id".to_string()), "missing customer.id");
-        assert!(result.contains(&"customer.descriptive_name".to_string()), "missing customer.descriptive_name");
-        assert!(result.contains(&"campaign.id".to_string()), "missing campaign.id");
-        assert!(result.contains(&"campaign.name".to_string()), "missing campaign.name");
-        assert!(result.contains(&"campaign.advertising_channel_type".to_string()), "missing campaign.advertising_channel_type");
+        assert!(
+            result.contains(&"customer.id".to_string()),
+            "missing customer.id"
+        );
+        assert!(
+            result.contains(&"customer.descriptive_name".to_string()),
+            "missing customer.descriptive_name"
+        );
+        assert!(
+            result.contains(&"campaign.id".to_string()),
+            "missing campaign.id"
+        );
+        assert!(
+            result.contains(&"campaign.name".to_string()),
+            "missing campaign.name"
+        );
+        assert!(
+            result.contains(&"campaign.advertising_channel_type".to_string()),
+            "missing campaign.advertising_channel_type"
+        );
     }
 
     #[test]
@@ -1822,11 +1843,26 @@ mod tests {
         let fields = build_test_run_fields();
         let result = compute_identity_fields("ad_group", &fields, &[]);
         // Inherits customer + campaign chain
-        assert!(result.contains(&"customer.id".to_string()), "missing customer.id");
-        assert!(result.contains(&"campaign.id".to_string()), "missing campaign.id");
-        assert!(result.contains(&"campaign.name".to_string()), "missing campaign.name");
-        assert!(result.contains(&"ad_group.id".to_string()), "missing ad_group.id");
-        assert!(result.contains(&"ad_group.name".to_string()), "missing ad_group.name");
+        assert!(
+            result.contains(&"customer.id".to_string()),
+            "missing customer.id"
+        );
+        assert!(
+            result.contains(&"campaign.id".to_string()),
+            "missing campaign.id"
+        );
+        assert!(
+            result.contains(&"campaign.name".to_string()),
+            "missing campaign.name"
+        );
+        assert!(
+            result.contains(&"ad_group.id".to_string()),
+            "missing ad_group.id"
+        );
+        assert!(
+            result.contains(&"ad_group.name".to_string()),
+            "missing ad_group.name"
+        );
     }
 
     #[test]
@@ -1834,11 +1870,26 @@ mod tests {
         let fields = build_test_run_fields();
         let result = compute_identity_fields("ad_group_ad", &fields, &[]);
         // Inherits customer + campaign + ad_group chain
-        assert!(result.contains(&"customer.id".to_string()), "missing customer.id");
-        assert!(result.contains(&"campaign.id".to_string()), "missing campaign.id");
-        assert!(result.contains(&"ad_group.id".to_string()), "missing ad_group.id");
-        assert!(result.contains(&"ad_group_ad.ad.id".to_string()), "missing ad_group_ad.ad.id");
-        assert!(result.contains(&"ad_group_ad.ad.type".to_string()), "missing ad_group_ad.ad.type");
+        assert!(
+            result.contains(&"customer.id".to_string()),
+            "missing customer.id"
+        );
+        assert!(
+            result.contains(&"campaign.id".to_string()),
+            "missing campaign.id"
+        );
+        assert!(
+            result.contains(&"ad_group.id".to_string()),
+            "missing ad_group.id"
+        );
+        assert!(
+            result.contains(&"ad_group_ad.ad.id".to_string()),
+            "missing ad_group_ad.ad.id"
+        );
+        assert!(
+            result.contains(&"ad_group_ad.ad.type".to_string()),
+            "missing ad_group_ad.ad.type"
+        );
     }
 
     #[test]
@@ -1852,11 +1903,26 @@ mod tests {
         ];
         let result = compute_identity_fields("keyword_view", &fields, &selectable_with);
         // Inherits customer + campaign + ad_group chain
-        assert!(result.contains(&"customer.id".to_string()), "missing customer.id");
-        assert!(result.contains(&"campaign.id".to_string()), "missing campaign.id");
-        assert!(result.contains(&"ad_group.id".to_string()), "missing ad_group.id");
+        assert!(
+            result.contains(&"customer.id".to_string()),
+            "missing customer.id"
+        );
+        assert!(
+            result.contains(&"campaign.id".to_string()),
+            "missing campaign.id"
+        );
+        assert!(
+            result.contains(&"ad_group.id".to_string()),
+            "missing ad_group.id"
+        );
         // keyword_view overrides: ad_group_criterion fields (available via selectable_with)
-        assert!(result.contains(&"ad_group_criterion.criterion_id".to_string()), "missing ad_group_criterion.criterion_id");
-        assert!(result.contains(&"ad_group_criterion.keyword.text".to_string()), "missing ad_group_criterion.keyword.text");
+        assert!(
+            result.contains(&"ad_group_criterion.criterion_id".to_string()),
+            "missing ad_group_criterion.criterion_id"
+        );
+        assert!(
+            result.contains(&"ad_group_criterion.keyword.text".to_string()),
+            "missing ad_group_criterion.keyword.text"
+        );
     }
 }

--- a/crates/mcc-gaql-common/src/http_client.rs
+++ b/crates/mcc-gaql-common/src/http_client.rs
@@ -4,7 +4,8 @@ use anyhow::Context;
 /// This is necessary for TLS to work in sandboxed environments like Claude Code.
 pub fn create_http_client(user_agent: &str, timeout_secs: u64) -> anyhow::Result<reqwest::Client> {
     // Build a root store with webpki-roots instead of the platform verifier
-    let root_store = rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let root_store =
+        rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
     // Create TLS configuration using webpki-roots (not platform verifier)
     let config = rustls::ClientConfig::builder_with_provider(
@@ -15,10 +16,10 @@ pub fn create_http_client(user_agent: &str, timeout_secs: u64) -> anyhow::Result
     .with_root_certificates(root_store)
     .with_no_client_auth();
 
-    Ok(reqwest::Client::builder()
+    reqwest::Client::builder()
         .use_preconfigured_tls(config)
         .user_agent(user_agent)
         .timeout(std::time::Duration::from_secs(timeout_secs))
         .build()
-        .context("Failed to build HTTP client")?)
+        .context("Failed to build HTTP client")
 }

--- a/crates/mcc-gaql-gen/src/bundle.rs
+++ b/crates/mcc-gaql-gen/src/bundle.rs
@@ -148,20 +148,20 @@ pub async fn create_bundle(output_path: &Path, query_cookbook_path: &Path) -> Re
     });
 
     // 3. Copy domain_knowledge.md (optional, may not exist yet)
-    if let Some(dk_src) = mcc_gaql_common::paths::config_file_path("domain_knowledge.md") {
-        if dk_src.exists() {
-            let dk_dest = temp_path.join("domain_knowledge.md");
-            fs::copy(&dk_src, &dk_dest)
-                .await
-                .context("Failed to copy domain_knowledge.md")?;
-            let dk_sha256 = compute_sha256(&dk_dest)?;
-            let dk_size = fs::metadata(&dk_dest).await?.len();
-            files.push(ManifestFile {
-                path: "domain_knowledge.md".to_string(),
-                size: dk_size,
-                sha256: dk_sha256,
-            });
-        }
+    if let Some(dk_src) = mcc_gaql_common::paths::config_file_path("domain_knowledge.md")
+        && dk_src.exists()
+    {
+        let dk_dest = temp_path.join("domain_knowledge.md");
+        fs::copy(&dk_src, &dk_dest)
+            .await
+            .context("Failed to copy domain_knowledge.md")?;
+        let dk_sha256 = compute_sha256(&dk_dest)?;
+        let dk_size = fs::metadata(&dk_dest).await?.len();
+        files.push(ManifestFile {
+            path: "domain_knowledge.md".to_string(),
+            size: dk_size,
+            sha256: dk_sha256,
+        });
     }
 
     // 5. Copy LanceDB directory
@@ -306,10 +306,7 @@ pub async fn extract_bundle(bundle_path: &Path, skip_validation: bool) -> Result
         );
     }
 
-    Ok(ExtractedBundle {
-        manifest,
-        temp_dir,
-    })
+    Ok(ExtractedBundle { manifest, temp_dir })
 }
 
 /// Download bundle from URL to temp file
@@ -322,11 +319,7 @@ pub async fn download_bundle(url: &str) -> Result<PathBuf> {
         return Ok(PathBuf::from(path));
     }
 
-    let client = http_client::create_http_client(
-        "mcc-gaql-gen (bundle downloader)",
-        300,
-    )?;
-
+    let client = http_client::create_http_client("mcc-gaql-gen (bundle downloader)", 300)?;
 
     let response = client
         .get(url)
@@ -363,7 +356,10 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
 
     log::debug!("install_bundle: cache_dir={:?}", cache_dir);
     log::debug!("install_bundle: config_dir={:?}", config_dir);
-    log::debug!("install_bundle: bundle temp_dir={:?}", bundle.temp_dir.path());
+    log::debug!(
+        "install_bundle: bundle temp_dir={:?}",
+        bundle.temp_dir.path()
+    );
 
     // Ensure directories exist
     fs::create_dir_all(&cache_dir)
@@ -394,8 +390,15 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
     // Copy field_metadata_enriched.json to cache
     let enriched_src = bundle.file_path("field_metadata_enriched.json");
     let enriched_dest = cache_dir.join("field_metadata_enriched.json");
-    log::debug!("install_bundle: copying {:?} -> {:?}", enriched_src, enriched_dest);
-    log::debug!("install_bundle: enriched_src exists={}", enriched_src.exists());
+    log::debug!(
+        "install_bundle: copying {:?} -> {:?}",
+        enriched_src,
+        enriched_dest
+    );
+    log::debug!(
+        "install_bundle: enriched_src exists={}",
+        enriched_src.exists()
+    );
     fs::copy(&enriched_src, &enriched_dest)
         .await
         .with_context(|| {
@@ -409,14 +412,21 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
     // Copy query_cookbook.toml to config
     let cookbook_src = bundle.file_path("query_cookbook.toml");
     let cookbook_dest = config_dir.join("query_cookbook.toml");
-    log::debug!("install_bundle: copying {:?} -> {:?}", cookbook_src, cookbook_dest);
-    log::debug!("install_bundle: cookbook_src exists={}", cookbook_src.exists());
+    log::debug!(
+        "install_bundle: copying {:?} -> {:?}",
+        cookbook_src,
+        cookbook_dest
+    );
+    log::debug!(
+        "install_bundle: cookbook_src exists={}",
+        cookbook_src.exists()
+    );
     if cookbook_src.exists() {
         // Remove existing file/symlink at destination to avoid broken-symlink errors
         if cookbook_dest.exists() || cookbook_dest.symlink_metadata().is_ok() {
-            fs::remove_file(&cookbook_dest).await.with_context(|| {
-                format!("Failed to remove existing {:?}", cookbook_dest)
-            })?;
+            fs::remove_file(&cookbook_dest)
+                .await
+                .with_context(|| format!("Failed to remove existing {:?}", cookbook_dest))?;
             log::debug!("install_bundle: removed existing {:?}", cookbook_dest);
         }
         fs::copy(&cookbook_src, &cookbook_dest)
@@ -437,18 +447,16 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
     let dk_dest = config_dir.join("domain_knowledge.md");
     if dk_src.exists() {
         if dk_dest.exists() || dk_dest.symlink_metadata().is_ok() {
-            fs::remove_file(&dk_dest).await.with_context(|| {
-                format!("Failed to remove existing {:?}", dk_dest)
-            })?;
+            fs::remove_file(&dk_dest)
+                .await
+                .with_context(|| format!("Failed to remove existing {:?}", dk_dest))?;
         }
-        fs::copy(&dk_src, &dk_dest)
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to copy domain knowledge: {:?} -> {:?}",
-                    dk_src, dk_dest
-                )
-            })?;
+        fs::copy(&dk_src, &dk_dest).await.with_context(|| {
+            format!(
+                "Failed to copy domain knowledge: {:?} -> {:?}",
+                dk_src, dk_dest
+            )
+        })?;
         log::info!("Installed domain_knowledge.md");
     } else {
         log::warn!("domain_knowledge.md not found in bundle, skipping");
@@ -457,8 +465,15 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
     // Copy LanceDB directory
     let lancedb_src = bundle.file_path("lancedb");
     let lancedb_dest = cache_dir.join("lancedb");
-    log::debug!("install_bundle: copying lancedb {:?} -> {:?}", lancedb_src, lancedb_dest);
-    log::debug!("install_bundle: lancedb_src exists={}", lancedb_src.exists());
+    log::debug!(
+        "install_bundle: copying lancedb {:?} -> {:?}",
+        lancedb_src,
+        lancedb_dest
+    );
+    log::debug!(
+        "install_bundle: lancedb_src exists={}",
+        lancedb_src.exists()
+    );
 
     // Remove existing LanceDB if it exists
     if lancedb_dest.exists() {
@@ -484,7 +499,10 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
     if field_hash_src.exists() {
         let dest = cache_dir.join("field_metadata.hash");
         fs::copy(&field_hash_src, &dest).await.with_context(|| {
-            format!("Failed to copy field_metadata.hash: {:?} -> {:?}", field_hash_src, dest)
+            format!(
+                "Failed to copy field_metadata.hash: {:?} -> {:?}",
+                field_hash_src, dest
+            )
         })?;
         log::info!("Installed field_metadata.hash");
     }
@@ -497,7 +515,10 @@ pub async fn install_bundle(bundle: &ExtractedBundle, force: bool) -> Result<()>
     if query_hash_src.exists() {
         let dest = cache_dir.join("query_cookbook.hash");
         fs::copy(&query_hash_src, &dest).await.with_context(|| {
-            format!("Failed to copy query_cookbook.hash: {:?} -> {:?}", query_hash_src, dest)
+            format!(
+                "Failed to copy query_cookbook.hash: {:?} -> {:?}",
+                query_hash_src, dest
+            )
         })?;
         log::info!("Installed query_cookbook.hash");
     }

--- a/crates/mcc-gaql-gen/src/enricher.rs
+++ b/crates/mcc-gaql-gen/src/enricher.rs
@@ -17,9 +17,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::time::{Duration, sleep};
 
-use mcc_gaql_common::field_metadata::{
-    FieldMetadata, FieldMetadataCache, ResourceMetadata,
-};
+use mcc_gaql_common::field_metadata::{FieldMetadata, FieldMetadataCache, ResourceMetadata};
 
 use crate::rag::{format_llm_request_debug, format_llm_response_debug};
 
@@ -332,9 +330,9 @@ impl MetadataEnricher {
                     .resource_metadata
                     .as_mut()
                     .and_then(|m| m.get_mut(&resource))
-                {
-                    rm.description = Some(desc);
-                }
+            {
+                rm.description = Some(desc);
+            }
         }
 
         let enriched = cache.enriched_field_count();

--- a/crates/mcc-gaql-gen/src/formatter.rs
+++ b/crates/mcc-gaql-gen/src/formatter.rs
@@ -21,6 +21,29 @@ const LLM_ENRICHED: &str = "[llm-enriched]";
 /// LLM category limit (matches Phase 3 field selection behavior)
 const LLM_CATEGORY_LIMIT: usize = 15;
 
+/// Categorize selectable_with fields into segments, metrics, and other
+fn categorize_selectable_with(selectable_with: &[String]) -> (Vec<&str>, Vec<&str>, Vec<&str>) {
+    let mut segments = Vec::new();
+    let mut metrics = Vec::new();
+    let mut other = Vec::new();
+
+    for field in selectable_with {
+        if field.starts_with("segments.") {
+            segments.push(field.as_str());
+        } else if field.starts_with("metrics.") {
+            metrics.push(field.as_str());
+        } else {
+            other.push(field.as_str());
+        }
+    }
+
+    segments.sort();
+    metrics.sort();
+    other.sort();
+
+    (segments, metrics, other)
+}
+
 /// Result of a query match
 #[derive(Debug)]
 pub enum QueryResult {
@@ -56,45 +79,45 @@ pub fn match_query(cache: &FieldMetadataCache, query: &str) -> Result<QueryResul
             .as_ref()
             .map(|rm| rm.contains_key(query))
             .unwrap_or(false)
-        {
-            // Get all fields for this resource
-            let resource_fields = cache.get_resource_fields(query);
-            let mut attributes = Vec::new();
-            let mut metrics = Vec::new();
-            let mut segments = Vec::new();
+    {
+        // Get all fields for this resource
+        let resource_fields = cache.get_resource_fields(query);
+        let mut attributes = Vec::new();
+        let mut metrics = Vec::new();
+        let mut segments = Vec::new();
 
-            for field in resource_fields {
-                match field.category.as_str() {
-                    "ATTRIBUTE" | "Attribute" | "attribute" => attributes.push(field.clone()),
-                    "METRIC" | "Metric" | "metric" => metrics.push(field.clone()),
-                    "SEGMENT" | "Segment" | "segment" => segments.push(field.clone()),
-                    _ => {}
-                }
+        for field in resource_fields {
+            match field.category.as_str() {
+                "ATTRIBUTE" | "Attribute" | "attribute" => attributes.push(field.clone()),
+                "METRIC" | "Metric" | "metric" => metrics.push(field.clone()),
+                "SEGMENT" | "Segment" | "segment" => segments.push(field.clone()),
+                _ => {}
             }
-
-            let metadata = cache
-                .resource_metadata
-                .as_ref()
-                .and_then(|rm| rm.get(query))
-                .cloned()
-                .unwrap_or_else(|| ResourceMetadata {
-                    name: query.to_string(),
-                    selectable_with: vec![],
-                    key_attributes: vec![],
-                    key_metrics: vec![],
-                    field_count: attributes.len() + metrics.len() + segments.len(),
-                    description: None,
-                    uses_fallback: false,
-                    identity_fields: vec![],
-                });
-
-            return Ok(QueryResult::Resource {
-                metadata,
-                attributes,
-                metrics,
-                segments,
-            });
         }
+
+        let metadata = cache
+            .resource_metadata
+            .as_ref()
+            .and_then(|rm| rm.get(query))
+            .cloned()
+            .unwrap_or_else(|| ResourceMetadata {
+                name: query.to_string(),
+                selectable_with: vec![],
+                key_attributes: vec![],
+                key_metrics: vec![],
+                field_count: attributes.len() + metrics.len() + segments.len(),
+                description: None,
+                uses_fallback: false,
+                identity_fields: vec![],
+            });
+
+        return Ok(QueryResult::Resource {
+            metadata,
+            attributes,
+            metrics,
+            segments,
+        });
+    }
 
     // If full field name OR no resource match, try field match
     if let Some(field) = cache.get_field(query) {
@@ -535,6 +558,64 @@ pub fn format_llm(query_result: &QueryResult, show_all: bool) -> String {
                 ));
             }
 
+            // Show selectable_with counts
+            let (selectable_segments, selectable_metrics, selectable_other) =
+                categorize_selectable_with(&metadata.selectable_with);
+
+            if !selectable_segments.is_empty() {
+                output.push_str(&format!(
+                    "Selectable segments ({}): {}\n",
+                    selectable_segments.len(),
+                    selectable_segments
+                        .iter()
+                        .take(10)
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+                if selectable_segments.len() > 10 {
+                    output.push_str(&format!(
+                        "  ... and {} more\n",
+                        selectable_segments.len() - 10
+                    ));
+                }
+            }
+
+            if !selectable_metrics.is_empty() {
+                output.push_str(&format!(
+                    "Selectable metrics ({}): {}\n",
+                    selectable_metrics.len(),
+                    selectable_metrics
+                        .iter()
+                        .take(10)
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+                if selectable_metrics.len() > 10 {
+                    output.push_str(&format!(
+                        "  ... and {} more\n",
+                        selectable_metrics.len() - 10
+                    ));
+                }
+            }
+
+            if !selectable_other.is_empty() {
+                output.push_str(&format!(
+                    "Selectable other ({}): {}\n",
+                    selectable_other.len(),
+                    selectable_other
+                        .iter()
+                        .take(10)
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+                if selectable_other.len() > 10 {
+                    output.push_str(&format!("  ... and {} more\n", selectable_other.len() - 10));
+                }
+            }
+
             output.push('\n');
 
             // Apply category limit
@@ -717,6 +798,49 @@ pub fn format_full(query_result: &QueryResult) -> String {
                     output.push_str(&format_field_full(field));
                 }
             }
+
+            // Show selectable_with fields categorized
+            let (selectable_segments, selectable_metrics, selectable_other) =
+                categorize_selectable_with(&metadata.selectable_with);
+
+            if !selectable_segments.is_empty()
+                || !selectable_metrics.is_empty()
+                || !selectable_other.is_empty()
+            {
+                output.push_str("\n--- SELECTABLE WITH (auto-joined fields) ---\n\n");
+
+                if !selectable_segments.is_empty() {
+                    output.push_str(&format!(
+                        "### SELECTABLE SEGMENTS ({})\n",
+                        selectable_segments.len()
+                    ));
+                    for seg in &selectable_segments {
+                        output.push_str(&format!("  - {}\n", seg));
+                    }
+                    output.push('\n');
+                }
+
+                if !selectable_metrics.is_empty() {
+                    output.push_str(&format!(
+                        "### SELECTABLE METRICS ({})\n",
+                        selectable_metrics.len()
+                    ));
+                    for metric in &selectable_metrics {
+                        output.push_str(&format!("  - {}\n", metric));
+                    }
+                    output.push('\n');
+                }
+
+                if !selectable_other.is_empty() {
+                    output.push_str(&format!(
+                        "### SELECTABLE OTHER ({})\n",
+                        selectable_other.len()
+                    ));
+                    for field in &selectable_other {
+                        output.push_str(&format!("  - {}\n", field));
+                    }
+                }
+            }
         }
         QueryResult::Pattern { fields } => {
             let total: usize = fields.values().map(|v| v.len()).sum();
@@ -740,21 +864,19 @@ pub fn format_full(query_result: &QueryResult) -> String {
 
 /// Format a single field with all metadata
 fn format_field_full(field: &FieldMetadata) -> String {
-    let desc_indicator = if field.description.is_none()
-        || field.description.as_ref().is_none_or(|d| d.is_empty())
-    {
-        format!(" {}", NO_DESCRIPTION)
-    } else {
-        String::new()
-    };
+    let desc_indicator =
+        if field.description.is_none() || field.description.as_ref().is_none_or(|d| d.is_empty()) {
+            format!(" {}", NO_DESCRIPTION)
+        } else {
+            String::new()
+        };
 
-    let notes_indicator = if field.usage_notes.is_none()
-        || field.usage_notes.as_ref().is_none_or(|n| n.is_empty())
-    {
-        format!(" {}", NO_USAGE_NOTES)
-    } else {
-        String::new()
-    };
+    let notes_indicator =
+        if field.usage_notes.is_none() || field.usage_notes.as_ref().is_none_or(|n| n.is_empty()) {
+            format!(" {}", NO_USAGE_NOTES)
+        } else {
+            String::new()
+        };
 
     let mut output = format!("- {}{}{}\n", field.name, desc_indicator, notes_indicator);
 
@@ -802,14 +924,16 @@ fn format_field_full(field: &FieldMetadata) -> String {
     }
 
     if let Some(desc) = &field.description
-        && !desc.is_empty() {
-            output.push_str(&format!("  Description: {}\n", desc));
-        }
+        && !desc.is_empty()
+    {
+        output.push_str(&format!("  Description: {}\n", desc));
+    }
 
     if let Some(notes) = &field.usage_notes
-        && !notes.is_empty() {
-            output.push_str(&format!("  Usage notes: {}\n", notes));
-        }
+        && !notes.is_empty()
+    {
+        output.push_str(&format!("  Usage notes: {}\n", notes));
+    }
 
     output
 }
@@ -1039,14 +1163,13 @@ fn format_field_with_llm_marker(
     );
 
     // Add before/after if enriched
-    if was_enriched
-        && let Some(ne_field) = non_enriched_field {
-            output.push_str(&format!(
-                "  Before: {}\n",
-                ne_field.description.as_deref().unwrap_or("")
-            ));
-            output.push_str(&format!("  After: {}\n", desc));
-        }
+    if was_enriched && let Some(ne_field) = non_enriched_field {
+        output.push_str(&format!(
+            "  Before: {}\n",
+            ne_field.description.as_deref().unwrap_or("")
+        ));
+        output.push_str(&format!("  After: {}\n", desc));
+    }
 
     output
 }

--- a/crates/mcc-gaql-gen/src/main.rs
+++ b/crates/mcc-gaql-gen/src/main.rs
@@ -47,6 +47,19 @@ use mcc_gaql_common::paths::{config_file_path, field_metadata_enriched_path};
 /// Core resources for test-run mode
 const TEST_RUN_RESOURCES: &[&str] = &["campaign", "ad_group", "ad_group_ad", "keyword_view"];
 
+/// Parameters for generate command
+struct GenerateParams {
+    prompt: String,
+    queries: Option<String>,
+    metadata: Option<PathBuf>,
+    no_defaults: bool,
+    use_query_cookbook: bool,
+    explain: bool,
+    verbose: bool,
+    validate: bool,
+    profile: Option<String>,
+}
+
 /// Filter resources for test-run mode
 fn filter_test_resources(resources: Vec<String>) -> Vec<String> {
     let test_set: std::collections::HashSet<_> = TEST_RUN_RESOURCES.iter().cloned().collect();
@@ -336,17 +349,17 @@ async fn main() -> Result<()> {
             validate,
             profile,
         } => {
-            cmd_generate(
+            cmd_generate(GenerateParams {
                 prompt,
                 queries,
                 metadata,
                 no_defaults,
                 use_query_cookbook,
                 explain,
-                cli.verbose,
+                verbose: cli.verbose,
                 validate,
                 profile,
-            )
+            })
             .await?;
         }
 
@@ -413,8 +426,12 @@ async fn cmd_scrape(
     test_run: bool,
 ) -> Result<()> {
     // Print deprecation warning
-    eprintln!("⚠️  WARNING: The 'scrape' command is deprecated and may be removed in a future version.");
-    eprintln!("   Use 'mcc-gaql-gen parse-protos' instead for reliable, authoritative field documentation.");
+    eprintln!(
+        "⚠️  WARNING: The 'scrape' command is deprecated and may be removed in a future version."
+    );
+    eprintln!(
+        "   Use 'mcc-gaql-gen parse-protos' instead for reliable, authoritative field documentation."
+    );
     eprintln!();
 
     // Load metadata cache to get the list of resources
@@ -488,18 +505,16 @@ fn resource_missing_enrichment(
     }
 
     // Check if any field has a description
-    let has_field_descriptions = resource_fields.iter().any(|f| {
-        f.description.as_ref().is_some_and(|d| !d.is_empty())
-    });
+    let has_field_descriptions = resource_fields
+        .iter()
+        .any(|f| f.description.as_ref().is_some_and(|d| !d.is_empty()));
 
     // Check if resource metadata has key_attributes/key_metrics
     let has_resource_metadata = enriched_cache
         .resource_metadata
         .as_ref()
         .and_then(|rm| rm.get(resource))
-        .map(|meta| {
-            !meta.key_attributes.is_empty() || !meta.key_metrics.is_empty()
-        })
+        .map(|meta| !meta.key_attributes.is_empty() || !meta.key_metrics.is_empty())
         .unwrap_or(false);
 
     // Missing enrichment if neither field descriptions nor resource metadata exist
@@ -555,19 +570,21 @@ async fn cmd_enrich(
 
         if let Some(ref path) = enriched_path {
             if path.exists() {
-                println!("Loading existing enriched cache to identify resources missing enrichment...");
+                println!(
+                    "Loading existing enriched cache to identify resources missing enrichment..."
+                );
                 match FieldMetadataCache::load_from_disk(path).await {
                     Ok(enriched_cache) => {
                         let all_resources = cache.get_resources();
                         let missing_resources: Vec<String> = all_resources
                             .into_iter()
-                            .filter(|r| {
-                                resource_missing_enrichment(&cache, &enriched_cache, r)
-                            })
+                            .filter(|r| resource_missing_enrichment(&cache, &enriched_cache, r))
                             .collect();
 
                         if missing_resources.is_empty() {
-                            println!("All resources are already enriched. Use --all to re-enrich everything.");
+                            println!(
+                                "All resources are already enriched. Use --all to re-enrich everything."
+                            );
                             return Ok(());
                         }
 
@@ -580,7 +597,10 @@ async fn cmd_enrich(
                         cache.retain_resources(&missing_resources);
                     }
                     Err(e) => {
-                        println!("Could not load existing enriched cache ({}). Processing all resources.", e);
+                        println!(
+                            "Could not load existing enriched cache ({}). Processing all resources.",
+                            e
+                        );
                     }
                 }
             } else {
@@ -687,11 +707,12 @@ async fn cmd_enrich(
     // Backup existing enriched cache before modifying
     if enriched_path.exists() {
         let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
-        let backup_path = enriched_path.with_file_name(format!(
-            "field_metadata_enriched_{}.json",
-            timestamp
-        ));
-        println!("\nBacking up existing enriched cache to {:?}...", backup_path);
+        let backup_path =
+            enriched_path.with_file_name(format!("field_metadata_enriched_{}.json", timestamp));
+        println!(
+            "\nBacking up existing enriched cache to {:?}...",
+            backup_path
+        );
         std::fs::copy(&enriched_path, &backup_path)?;
     }
 
@@ -736,19 +757,21 @@ async fn cmd_enrich_proto(
 
         if let Some(ref path) = enriched_path {
             if path.exists() {
-                println!("Loading existing enriched cache to identify resources missing enrichment...");
+                println!(
+                    "Loading existing enriched cache to identify resources missing enrichment..."
+                );
                 match FieldMetadataCache::load_from_disk(path).await {
                     Ok(enriched_cache) => {
                         let all_resources = cache.get_resources();
                         let missing_resources: Vec<String> = all_resources
                             .into_iter()
-                            .filter(|r| {
-                                resource_missing_enrichment(cache, &enriched_cache, r)
-                            })
+                            .filter(|r| resource_missing_enrichment(cache, &enriched_cache, r))
                             .collect();
 
                         if missing_resources.is_empty() {
-                            println!("All resources are already enriched. Use --all to re-enrich everything.");
+                            println!(
+                                "All resources are already enriched. Use --all to re-enrich everything."
+                            );
                             return Ok(());
                         }
 
@@ -761,7 +784,10 @@ async fn cmd_enrich_proto(
                         cache.retain_resources(&missing_resources);
                     }
                     Err(e) => {
-                        println!("Could not load existing enriched cache ({}). Processing all resources.", e);
+                        println!(
+                            "Could not load existing enriched cache ({}). Processing all resources.",
+                            e
+                        );
                     }
                 }
             } else {
@@ -825,11 +851,12 @@ async fn cmd_enrich_proto(
     // Backup existing enriched cache before modifying
     if enriched_path.exists() {
         let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
-        let backup_path = enriched_path.with_file_name(format!(
-            "field_metadata_enriched_{}.json",
-            timestamp
-        ));
-        println!("\nBacking up existing enriched cache to {:?}...", backup_path);
+        let backup_path =
+            enriched_path.with_file_name(format!("field_metadata_enriched_{}.json", timestamp));
+        println!(
+            "\nBacking up existing enriched cache to {:?}...",
+            backup_path
+        );
         std::fs::copy(&enriched_path, &backup_path)?;
     }
 
@@ -859,23 +886,13 @@ async fn cmd_enrich_proto(
 }
 
 /// Generate a GAQL query from a natural language prompt
-async fn cmd_generate(
-    prompt: String,
-    queries: Option<String>,
-    metadata: Option<PathBuf>,
-    no_defaults: bool,
-    use_query_cookbook: bool,
-    explain: bool,
-    verbose: bool,
-    validate: bool,
-    profile: Option<String>,
-) -> Result<()> {
+async fn cmd_generate(params: GenerateParams) -> Result<()> {
     validate_llm_env()?;
 
     let llm_config = rag::LlmConfig::from_env();
 
     // Load query cookbook
-    let example_queries: Vec<QueryEntry> = if let Some(queries_file) = queries {
+    let example_queries: Vec<QueryEntry> = if let Some(queries_file) = params.queries {
         // Explicit --queries flag provided
         let queries_path = config_file_path(&queries_file)
             .with_context(|| format!("Could not find queries file: {}", queries_file))?;
@@ -903,7 +920,8 @@ async fn cmd_generate(
     };
 
     // Load field metadata
-    let metadata_path = metadata
+    let metadata_path = params
+        .metadata
         .or_else(|| mcc_gaql_common::paths::field_metadata_enriched_path().ok())
         .context("Could not determine enriched metadata path. Use --metadata to specify it.")?;
     log::info!("Loading field metadata from {:?}...", metadata_path);
@@ -940,20 +958,20 @@ async fn cmd_generate(
     }
 
     // Cache is valid - proceed with generation
-    log::info!("Cache valid. Generating GAQL for: \"{}\"", prompt);
+    log::info!("Cache valid. Generating GAQL for: \"{}\"", params.prompt);
 
     // Build pipeline config
     let pipeline_config = rag::PipelineConfig {
-        add_defaults: !no_defaults,
-        use_query_cookbook,
-        explain,
+        add_defaults: !params.no_defaults,
+        use_query_cookbook: params.use_query_cookbook,
+        explain: params.explain,
     };
 
     // Generate GAQL using MultiStepRAGAgent
     let result = rag::convert_to_gaql(
         example_queries,
         field_cache,
-        &prompt,
+        &params.prompt,
         &llm_config,
         pipeline_config,
     )
@@ -962,16 +980,16 @@ async fn cmd_generate(
     println!("{}", result.query);
 
     // Validate generated query against Google Ads API if requested
-    if validate {
-        let exit_code = match run_validation(&result.query, profile).await {
+    if params.validate {
+        let exit_code = match run_validation(&result.query, params.profile).await {
             Ok(()) => {
                 eprintln!("Validation: PASSED");
                 0
             }
             Err(e) => {
                 let msg = e.to_string();
-                if msg.starts_with("__config_error__:") {
-                    eprintln!("Validation error: {}", &msg["__config_error__:".len()..]);
+                if let Some(stripped) = msg.strip_prefix("__config_error__:") {
+                    eprintln!("Validation error: {}", stripped);
                     2
                 } else {
                     eprintln!("Validation: FAILED – {}", msg);
@@ -985,8 +1003,8 @@ async fn cmd_generate(
     }
 
     // Print explanation if flag is set
-    if explain {
-        rag::print_selection_explanation(&result.pipeline_trace, &prompt);
+    if params.explain {
+        rag::print_selection_explanation(&result.pipeline_trace, &params.prompt);
     }
 
     // Log validation errors/warnings if any
@@ -1004,7 +1022,7 @@ async fn cmd_generate(
     }
 
     // Log pipeline trace if verbose
-    if verbose {
+    if params.verbose {
         log::debug!("--- Pipeline Trace ---");
         log::debug!(
             "Phase 1 - Primary resource: {}",
@@ -1063,16 +1081,17 @@ async fn cmd_generate(
 /// Returns Err with API error message for invalid queries (exit 1).
 async fn run_validation(query: &str, profile: Option<String>) -> Result<()> {
     use mcc_gaql::config as mcc_config;
-    use mcc_gaql::googleads::{ApiAccessConfig, generate_token_cache_filename, get_api_access, validate_gaql_query};
+    use mcc_gaql::googleads::{
+        ApiAccessConfig, generate_token_cache_filename, get_api_access, validate_gaql_query,
+    };
     use mcc_gaql_common::paths::config_file_path;
 
     // Resolve profile name
     let profile_name = match profile {
         Some(p) => p,
         None => {
-            let profiles = mcc_config::list_profiles().map_err(|e| {
-                anyhow::anyhow!("__config_error__:Failed to list profiles: {}", e)
-            })?;
+            let profiles = mcc_config::list_profiles()
+                .map_err(|e| anyhow::anyhow!("__config_error__:Failed to list profiles: {}", e))?;
             match profiles.len() {
                 0 => {
                     return Err(anyhow::anyhow!(
@@ -1091,7 +1110,11 @@ async fn run_validation(query: &str, profile: Option<String>) -> Result<()> {
 
     // Load config for the profile
     let config = mcc_config::load(&profile_name).map_err(|e| {
-        anyhow::anyhow!("__config_error__:Failed to load profile '{}': {}", profile_name, e)
+        anyhow::anyhow!(
+            "__config_error__:Failed to load profile '{}': {}",
+            profile_name,
+            e
+        )
     })?;
 
     // Resolve token cache filename
@@ -1139,9 +1162,9 @@ async fn run_validation(query: &str, profile: Option<String>) -> Result<()> {
         use_remote_auth: false,
     };
 
-    let access = get_api_access(&api_config).await.map_err(|e| {
-        anyhow::anyhow!("__config_error__:Authentication failed: {}", e)
-    })?;
+    let access = get_api_access(&api_config)
+        .await
+        .map_err(|e| anyhow::anyhow!("__config_error__:Authentication failed: {}", e))?;
 
     validate_gaql_query(access, &mcc_customer_id, query).await
 }
@@ -1659,7 +1682,10 @@ async fn cmd_backfill_identity(metadata: Option<PathBuf>, force: bool) -> Result
         println!("All resources already have identity fields. Nothing to do.");
     } else {
         let verb = if force { "Recomputed" } else { "Backfilled" };
-        println!("{} identity fields for {} resource(s). Saving...", verb, count);
+        println!(
+            "{} identity fields for {} resource(s). Saving...",
+            verb, count
+        );
         cache
             .save_to_disk(&metadata_path)
             .await

--- a/crates/mcc-gaql-gen/src/proto_docs_cache.rs
+++ b/crates/mcc-gaql-gen/src/proto_docs_cache.rs
@@ -416,10 +416,11 @@ pub fn merge_into_field_metadata_cache(
 
         // Look up proto field doc
         if let Some(proto_field) = proto_cache.get_field_doc(&message_name, &field_name_proto)
-            && !proto_field.description.is_empty() {
-                field_meta.description = Some(proto_field.description.clone());
-                enriched_count += 1;
-            }
+            && !proto_field.description.is_empty()
+        {
+            field_meta.description = Some(proto_field.description.clone());
+            enriched_count += 1;
+        }
     }
 
     // Also enrich resource-level metadata
@@ -431,9 +432,9 @@ pub fn merge_into_field_metadata_cache(
             if let Some(proto_desc) = proto_cache.get_resource_description(&message_name)
                 && (res_meta.description.is_none()
                     || res_meta.description.as_ref().is_none_or(|d| d.is_empty()))
-                {
-                    res_meta.description = Some(proto_desc.to_string());
-                }
+            {
+                res_meta.description = Some(proto_desc.to_string());
+            }
         }
     }
 
@@ -449,19 +450,21 @@ fn extract_commit_from_path(path: &Path) -> Result<String> {
 
     for (i, component) in components.iter().enumerate() {
         if let Component::Normal(name) = component
-            && name.to_str() == Some("checkouts") && i + 2 < components.len() {
-                // The component after googleads-rs-* should be the commit hash
-                if let Component::Normal(commit) = &components[i + 2] {
-                    let commit_str = commit.to_string_lossy();
-                    // Verify it looks like a commit hash (hex, at least 7 chars, no dots)
-                    if commit_str.len() >= 7
-                        && !commit_str.contains('.')
-                        && commit_str.chars().all(|c| c.is_ascii_hexdigit())
-                    {
-                        return Ok(commit_str.to_string());
-                    }
+            && name.to_str() == Some("checkouts")
+            && i + 2 < components.len()
+        {
+            // The component after googleads-rs-* should be the commit hash
+            if let Component::Normal(commit) = &components[i + 2] {
+                let commit_str = commit.to_string_lossy();
+                // Verify it looks like a commit hash (hex, at least 7 chars, no dots)
+                if commit_str.len() >= 7
+                    && !commit_str.contains('.')
+                    && commit_str.chars().all(|c| c.is_ascii_hexdigit())
+                {
+                    return Ok(commit_str.to_string());
                 }
             }
+        }
     }
 
     // Fallback: use "unknown" - cache will still work but won't invalidate on updates

--- a/crates/mcc-gaql-gen/src/r2.rs
+++ b/crates/mcc-gaql-gen/src/r2.rs
@@ -59,10 +59,7 @@ pub async fn download(public_base_url: &str, object_key: &str, dest_path: &Path)
     let url = format!("{}/{}", public_base_url.trim_end_matches('/'), object_key);
     log::info!("Downloading {} to {:?}", url, dest_path);
 
-        let client = http_client::create_http_client(
-        "mcc-gaql-gen (metadata downloader)",
-        120,
-    )?;
+    let client = http_client::create_http_client("mcc-gaql-gen (metadata downloader)", 120)?;
 
     let response = client
         .get(&url)
@@ -119,10 +116,7 @@ pub async fn download_bundle(url: &str, dest_path: &Path) -> Result<()> {
         return Ok(());
     }
 
-        let client = http_client::create_http_client(
-        "mcc-gaql-gen (bundle downloader)",
-        300,
-    )?;
+    let client = http_client::create_http_client("mcc-gaql-gen (bundle downloader)", 300)?;
 
     let response = client
         .get(url)
@@ -191,10 +185,7 @@ pub async fn upload(object_key: &str, source_path: &Path) -> Result<()> {
         &config.secret_key,
     )?;
 
-    let client = http_client::create_http_client(
-        "mcc-gaql-gen (metadata uploader)",
-        300,
-    )?;
+    let client = http_client::create_http_client("mcc-gaql-gen (metadata uploader)", 300)?;
 
     let response = client
         .put(&url)

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -1606,6 +1606,68 @@ impl MultiStepRAGAgent {
         })
     }
 
+    /// Summarize segment support for a resource in compact category format
+    /// Returns a string like "geo_target_*, date/time, device" or empty if no segments
+    fn summarize_resource_segments(&self, resource: &str) -> String {
+        let empty_vec = vec![];
+        let selectable_with = self
+            .field_cache
+            .resource_metadata
+            .as_ref()
+            .and_then(|m| m.get(resource))
+            .map(|rm| &rm.selectable_with)
+            .unwrap_or(&empty_vec);
+
+        let segments: Vec<&str> = selectable_with
+            .iter()
+            .filter(|f| f.starts_with("segments."))
+            .map(|f| f.strip_prefix("segments.").unwrap())
+            .collect();
+
+        if segments.is_empty() {
+            return String::new();
+        }
+
+        // Categorize and deduplicate
+        let mut categories: Vec<&str> = Vec::new();
+
+        if segments.iter().any(|s| s.starts_with("geo_target_")) {
+            categories.push("geo_target_* (city/state/region)");
+        }
+        if segments.iter().any(|s| s.starts_with("hotel_")) {
+            categories.push("hotel_*");
+        }
+        if segments.iter().any(|s| s.starts_with("product_")) {
+            categories.push("product_*");
+        }
+        if segments.iter().any(|s| {
+            [
+                "date",
+                "day_of_week",
+                "hour",
+                "month",
+                "week",
+                "year",
+                "quarter",
+                "month_of_year",
+            ]
+            .contains(s)
+        }) {
+            categories.push("date/time");
+        }
+        if segments.contains(&"device") {
+            categories.push("device");
+        }
+        if segments.iter().any(|s| s.starts_with("conversion")) {
+            categories.push("conversion");
+        }
+        if segments.iter().any(|s| s.starts_with("ad_network")) {
+            categories.push("ad_network");
+        }
+
+        categories.join(", ")
+    }
+
     /// Build a categorized, formatted list of resources for the LLM prompt
     fn build_categorized_resource_list(&self, resources: &[String]) -> String {
         // Define category patterns and their display names
@@ -1648,19 +1710,27 @@ impl MultiStepRAGAgent {
                 .and_then(|m| m.description.clone())
                 .unwrap_or_default();
 
+            // Add segment category summary to description
+            let segment_summary = self.summarize_resource_segments(resource);
+            let full_desc = if segment_summary.is_empty() {
+                description
+            } else {
+                format!("{} [Segments: {}]", description, segment_summary)
+            };
+
             let mut found = false;
             for (patterns, category) in &categories {
                 if patterns.iter().any(|p| resource.contains(p)) {
                     categorized
                         .entry(category.to_string())
                         .or_default()
-                        .push((resource.clone(), description.clone()));
+                        .push((resource.clone(), full_desc.clone()));
                     found = true;
                     break;
                 }
             }
             if !found {
-                uncategorized.push((resource.clone(), description));
+                uncategorized.push((resource.clone(), full_desc));
             }
         }
 
@@ -1676,9 +1746,21 @@ impl MultiStepRAGAgent {
                         if desc.is_empty() {
                             output.push_str(&format!("  - {}\n", name));
                         } else {
-                            // Truncate very long descriptions for readability
-                            let short_desc = if desc.len() > 120 {
-                                format!("{}...", &desc[..117])
+                            // Smart truncation: preserve segment annotation if present
+                            let short_desc = if desc.len() > 200 {
+                                // Check if there's a segment annotation
+                                if let Some(segment_start) = desc.find(" [Segments: ") {
+                                    // Truncate description but keep full segment annotation
+                                    let base_desc = &desc[..segment_start];
+                                    let segment_part = &desc[segment_start..];
+                                    if base_desc.len() > 120 {
+                                        format!("{}... {}", &base_desc[..117], segment_part)
+                                    } else {
+                                        desc.clone()
+                                    }
+                                } else {
+                                    format!("{}...", &desc[..197])
+                                }
                             } else {
                                 desc.clone()
                             };
@@ -1695,8 +1777,21 @@ impl MultiStepRAGAgent {
                 if desc.is_empty() {
                     output.push_str(&format!("  - {}\n", name));
                 } else {
-                    let short_desc = if desc.len() > 120 {
-                        format!("{}...", &desc[..117])
+                    // Smart truncation: preserve segment annotation if present
+                    let short_desc = if desc.len() > 200 {
+                        // Check if there's a segment annotation
+                        if let Some(segment_start) = desc.find(" [Segments: ") {
+                            // Truncate description but keep full segment annotation
+                            let base_desc = &desc[..segment_start];
+                            let segment_part = &desc[segment_start..];
+                            if base_desc.len() > 120 {
+                                format!("{}... {}", &base_desc[..117], segment_part)
+                            } else {
+                                desc
+                            }
+                        } else {
+                            format!("{}...", &desc[..197])
+                        }
                     } else {
                         desc
                     };
@@ -1987,7 +2082,7 @@ impl MultiStepRAGAgent {
                 }
             };
 
-        // Build resource information for sampling
+        // Build resource information for sampling (with segment summaries)
         let resource_info: Vec<(String, String)> = resources
             .iter()
             .map(|r| {
@@ -1997,7 +2092,16 @@ impl MultiStepRAGAgent {
                     .as_ref()
                     .and_then(|m| m.get(r));
                 let desc = rm.and_then(|m| m.description.as_deref()).unwrap_or("");
-                (r.clone(), desc.to_string())
+
+                // Add segment category summary
+                let segment_summary = self.summarize_resource_segments(r);
+                let full_desc = if segment_summary.is_empty() {
+                    desc.to_string()
+                } else {
+                    format!("{} [Segments: {}]", desc, segment_summary)
+                };
+
+                (r.clone(), full_desc)
             })
             .collect();
 

--- a/crates/mcc-gaql-gen/src/rag.rs
+++ b/crates/mcc-gaql-gen/src/rag.rs
@@ -946,7 +946,9 @@ pub async fn build_or_load_resource_vector_store(
                         SearchParams::default().distance_type(DistanceType::Cosine),
                     )
                     .await
-                    .map_err(|e| anyhow::anyhow!("Failed to create resource vector index: {}", e))?;
+                    .map_err(|e| {
+                        anyhow::anyhow!("Failed to create resource vector index: {}", e)
+                    })?;
 
                     log::info!(
                         "Successfully loaded resource entries from cache ({:.2}s)",
@@ -1023,12 +1025,8 @@ pub async fn build_or_load_resource_vector_store(
         })
         .collect();
 
-    let resource_embeddings = generate_embeddings_parallel(
-        resource_docs.clone(),
-        embedding_model.clone(),
-        50,
-    )
-    .await?;
+    let resource_embeddings =
+        generate_embeddings_parallel(resource_docs.clone(), embedding_model.clone(), 50).await?;
 
     log::info!(
         "Resource embeddings generated in {:.2}s",
@@ -1475,16 +1473,19 @@ impl DomainKnowledge {
     /// 1. User file at ~/.config/mcc-gaql/domain_knowledge.md (if exists)
     /// 2. Embedded default compiled into binary
     fn load() -> Self {
-        if let Some(path) = mcc_gaql_common::paths::config_file_path("domain_knowledge.md") {
-            if path.exists() {
-                match std::fs::read_to_string(&path) {
-                    Ok(content) => {
-                        log::info!("Loaded user domain_knowledge.md from {:?}", path);
-                        return Self::parse(&content);
-                    }
-                    Err(e) => {
-                        log::warn!("Failed to read user domain_knowledge.md: {}, using embedded default", e);
-                    }
+        if let Some(path) = mcc_gaql_common::paths::config_file_path("domain_knowledge.md")
+            && path.exists()
+        {
+            match std::fs::read_to_string(&path) {
+                Ok(content) => {
+                    log::info!("Loaded user domain_knowledge.md from {:?}", path);
+                    return Self::parse(&content);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Failed to read user domain_knowledge.md: {}, using embedded default",
+                        e
+                    );
                 }
             }
         }
@@ -1740,34 +1741,35 @@ impl MultiStepRAGAgent {
         // Add categorized resources in order
         for (_, category_name) in &categories {
             if let Some(items) = categorized.get(*category_name)
-                && !items.is_empty() {
-                    output.push_str(&format!("\n--- {} ---\n", category_name));
-                    for (name, desc) in items {
-                        if desc.is_empty() {
-                            output.push_str(&format!("  - {}\n", name));
-                        } else {
-                            // Smart truncation: preserve segment annotation if present
-                            let short_desc = if desc.len() > 200 {
-                                // Check if there's a segment annotation
-                                if let Some(segment_start) = desc.find(" [Segments: ") {
-                                    // Truncate description but keep full segment annotation
-                                    let base_desc = &desc[..segment_start];
-                                    let segment_part = &desc[segment_start..];
-                                    if base_desc.len() > 120 {
-                                        format!("{}... {}", &base_desc[..117], segment_part)
-                                    } else {
-                                        desc.clone()
-                                    }
+                && !items.is_empty()
+            {
+                output.push_str(&format!("\n--- {} ---\n", category_name));
+                for (name, desc) in items {
+                    if desc.is_empty() {
+                        output.push_str(&format!("  - {}\n", name));
+                    } else {
+                        // Smart truncation: preserve segment annotation if present
+                        let short_desc = if desc.len() > 200 {
+                            // Check if there's a segment annotation
+                            if let Some(segment_start) = desc.find(" [Segments: ") {
+                                // Truncate description but keep full segment annotation
+                                let base_desc = &desc[..segment_start];
+                                let segment_part = &desc[segment_start..];
+                                if base_desc.len() > 120 {
+                                    format!("{}... {}", &base_desc[..117], segment_part)
                                 } else {
-                                    format!("{}...", &desc[..197])
+                                    desc.clone()
                                 }
                             } else {
-                                desc.clone()
-                            };
-                            output.push_str(&format!("  - {}: {}\n", name, short_desc));
-                        }
+                                format!("{}...", &desc[..197])
+                            }
+                        } else {
+                            desc.clone()
+                        };
+                        output.push_str(&format!("  - {}: {}\n", name, short_desc));
                     }
                 }
+            }
         }
 
         // Add uncategorized resources
@@ -2022,9 +2024,7 @@ impl MultiStepRAGAgent {
                 continue;
             }
             let category = categorize_resource(name);
-            if existing_categories.contains(category)
-                || seen_new_categories.contains(category)
-            {
+            if existing_categories.contains(category) || seen_new_categories.contains(category) {
                 continue;
             }
             let rm = &resource_metadata[name];
@@ -2053,34 +2053,31 @@ impl MultiStepRAGAgent {
         anyhow::Error,
     > {
         // --- RAG pre-filter ---
-        let (resources, used_rag) =
-            match self.retrieve_relevant_resources(user_query, 20).await {
-                Ok(candidates) if !candidates.is_empty() => {
-                    let top_score = candidates[0].score;
-                    if top_score >= Self::SIMILARITY_THRESHOLD {
-                        log::info!(
-                            "Phase 1: RAG pre-filter selected {} resources (top score={:.3})",
-                            candidates.len(),
-                            top_score
-                        );
-                        let names: Vec<String> =
-                            candidates.into_iter().map(|c| c.resource_name).collect();
-                        (names, true)
-                    } else {
-                        log::warn!(
-                            "Phase 1: Low RAG confidence ({:.3}), falling back to full resource list",
-                            top_score
-                        );
-                        (self.field_cache.get_resources(), false)
-                    }
-                }
-                Ok(_) | Err(_) => {
+        let (resources, used_rag) = match self.retrieve_relevant_resources(user_query, 20).await {
+            Ok(candidates) if !candidates.is_empty() => {
+                let top_score = candidates[0].score;
+                if top_score >= Self::SIMILARITY_THRESHOLD {
+                    log::info!(
+                        "Phase 1: RAG pre-filter selected {} resources (top score={:.3})",
+                        candidates.len(),
+                        top_score
+                    );
+                    let names: Vec<String> =
+                        candidates.into_iter().map(|c| c.resource_name).collect();
+                    (names, true)
+                } else {
                     log::warn!(
-                        "Phase 1: RAG resource search unavailable, using full resource list"
+                        "Phase 1: Low RAG confidence ({:.3}), falling back to full resource list",
+                        top_score
                     );
                     (self.field_cache.get_resources(), false)
                 }
-            };
+            }
+            Ok(_) | Err(_) => {
+                log::warn!("Phase 1: RAG resource search unavailable, using full resource list");
+                (self.field_cache.get_resources(), false)
+            }
+        };
 
         // Build resource information for sampling (with segment summaries)
         let resource_info: Vec<(String, String)> = resources
@@ -2145,6 +2142,7 @@ impl MultiStepRAGAgent {
         };
 
         let resource_guidance = self.domain_knowledge.section("Resource Selection Guidance");
+        let combined_resources = format!("{}{}", categorized_resources, cookbook_examples);
         let system_prompt = format!(
             r#"You are a Google Ads Query Language (GAQL) expert. Given a user query, determine:
 1. The primary resource to query FROM (e.g., campaign, ad_group, keyword_view)
@@ -2163,8 +2161,7 @@ Resource selection guidance:
 
 {}
 {}"#,
-            resource_list_header,
-            format!("{}{}", categorized_resources, cookbook_examples)
+            resource_list_header, combined_resources
         );
 
         let user_prompt = format!("User query: {}", user_query);
@@ -2254,8 +2251,7 @@ Resource selection guidance:
         let (primary, validated_related) = if !dropped.is_empty() {
             let mut promoted: Option<String> = None;
             for candidate in &dropped {
-                let candidate_selectable =
-                    self.field_cache.get_resource_selectable_with(candidate);
+                let candidate_selectable = self.field_cache.get_resource_selectable_with(candidate);
                 if candidate_selectable.contains(&primary) {
                     promoted = Some(candidate.clone());
                     break; // First qualifying candidate (preserves LLM priority order)
@@ -2320,13 +2316,12 @@ Resource selection guidance:
 
                 if !has_asset_access {
                     // Determine correct resource based on context
-                    let new_primary = if query_lower.contains("ad group")
-                        || query_lower.contains("ad_group")
-                    {
-                        "ad_group_asset"
-                    } else {
-                        "campaign_asset"
-                    };
+                    let new_primary =
+                        if query_lower.contains("ad group") || query_lower.contains("ad_group") {
+                            "ad_group_asset"
+                        } else {
+                            "campaign_asset"
+                        };
 
                     log::warn!(
                         "Phase 1: Overriding primary '{}' to '{}' - query requests asset details \
@@ -2338,8 +2333,7 @@ Resource selection guidance:
                     );
 
                     // Rebuild related resources for new primary
-                    let new_selectable =
-                        self.field_cache.get_resource_selectable_with(new_primary);
+                    let new_selectable = self.field_cache.get_resource_selectable_with(new_primary);
                     let new_related: Vec<String> = validated_related
                         .into_iter()
                         .filter(|r| new_selectable.contains(r))
@@ -2479,10 +2473,10 @@ Resource selection guidance:
                         // Only add if compatible with primary resource
                         if let Some(resource) = field.get_resource()
                             && (resource == primary || selectable_with.contains(&resource))
-                                && seen.insert(field.name.clone())
-                            {
-                                candidates.push(field.clone());
-                            }
+                            && seen.insert(field.name.clone())
+                        {
+                            candidates.push(field.clone());
+                        }
                     }
                 }
             }
@@ -2652,23 +2646,47 @@ Resource selection guidance:
         // The segment vector search (15 samples) frequently misses segments.date when the user
         // query doesn't literally say "date". We detect temporal intent and force-include it.
         let temporal_keywords = [
-            "last week", "last 7 days", "last 14 days", "last 30 days", "last 60 days",
-            "last 90 days", "yesterday", "today", "this week", "this month", "last month",
-            "last business week", "this year", "last year", "ytd", "year to date",
-            "daily", "weekly", "monthly", "quarterly", "annual", "recent", "past week",
-            "past month", "past year", "last quarter", "this quarter",
+            "last week",
+            "last 7 days",
+            "last 14 days",
+            "last 30 days",
+            "last 60 days",
+            "last 90 days",
+            "yesterday",
+            "today",
+            "this week",
+            "this month",
+            "last month",
+            "last business week",
+            "this year",
+            "last year",
+            "ytd",
+            "year to date",
+            "daily",
+            "weekly",
+            "monthly",
+            "quarterly",
+            "annual",
+            "recent",
+            "past week",
+            "past month",
+            "past year",
+            "last quarter",
+            "this quarter",
         ];
         let query_lower = user_query.to_lowercase();
         let has_temporal = temporal_keywords.iter().any(|kw| query_lower.contains(kw));
         if has_temporal {
             let date_field_name = "segments.date";
-            if selectable_with.contains(&date_field_name.to_string()) {
-                if let Some(date_field) = self.field_cache.fields.get(date_field_name) {
-                    if seen.insert(date_field_name.to_string()) {
-                        candidates.push(date_field.clone());
-                        log::debug!("Phase 2: Force-injected {} for temporal query", date_field_name);
-                    }
-                }
+            if selectable_with.contains(&date_field_name.to_string())
+                && let Some(date_field) = self.field_cache.fields.get(date_field_name)
+                && seen.insert(date_field_name.to_string())
+            {
+                candidates.push(date_field.clone());
+                log::debug!(
+                    "Phase 2: Force-injected {} for temporal query",
+                    date_field_name
+                );
             }
         }
 
@@ -2677,13 +2695,12 @@ Resource selection guidance:
         // In an MCC environment, account identifiers are universally useful context for any query.
         // They are added as candidates only; the LLM decides whether to include them in SELECT.
         for field_name in &["customer.id", "customer.descriptive_name"] {
-            if selectable_with.contains(&field_name.to_string()) || primary == "customer" {
-                if let Some(field) = self.field_cache.fields.get(*field_name) {
-                    if seen.insert(field_name.to_string()) {
-                        candidates.push(field.clone());
-                        log::debug!("Phase 2: Force-injected {} (always-on for MCC)", field_name);
-                    }
-                }
+            if (selectable_with.contains(&field_name.to_string()) || primary == "customer")
+                && let Some(field) = self.field_cache.fields.get(*field_name)
+                && seen.insert(field_name.to_string())
+            {
+                candidates.push(field.clone());
+                log::debug!("Phase 2: Force-injected {} (always-on for MCC)", field_name);
             }
         }
 
@@ -2702,13 +2719,15 @@ Resource selection guidance:
                 "metrics.search_top_impression_share",
             ];
             for field_name in &impression_share_metrics {
-                if selectable_with.contains(&field_name.to_string()) {
-                    if let Some(field) = self.field_cache.fields.get(*field_name) {
-                        if seen.insert(field_name.to_string()) {
-                            candidates.push(field.clone());
-                            log::debug!("Phase 2: Force-injected {} for impression share query", field_name);
-                        }
-                    }
+                if selectable_with.contains(&field_name.to_string())
+                    && let Some(field) = self.field_cache.fields.get(*field_name)
+                    && seen.insert(field_name.to_string())
+                {
+                    candidates.push(field.clone());
+                    log::debug!(
+                        "Phase 2: Force-injected {} for impression share query",
+                        field_name
+                    );
                 }
             }
         }
@@ -2723,23 +2742,24 @@ Resource selection guidance:
             .and_then(|m| m.get(primary))
             .map(|rm| {
                 if rm.identity_fields.is_empty() {
-                    log::debug!("Phase 2: identity_fields empty for {primary} — cache may need backfill");
+                    log::debug!(
+                        "Phase 2: identity_fields empty for {primary} — cache may need backfill"
+                    );
                 }
                 rm.identity_fields.clone()
             })
             .unwrap_or_default();
         for field_name in &identity_fields {
-            if selectable_with.contains(field_name) || field_name.starts_with("customer.") {
-                if let Some(field) = self.field_cache.fields.get(field_name.as_str()) {
-                    if seen.insert(field_name.clone()) {
-                        candidates.push(field.clone());
-                        log::debug!(
-                            "Phase 2: Force-injected {} (identity field for {})",
-                            field_name,
-                            primary
-                        );
-                    }
-                }
+            if (selectable_with.contains(field_name) || field_name.starts_with("customer."))
+                && let Some(field) = self.field_cache.fields.get(field_name.as_str())
+                && seen.insert(field_name.clone())
+            {
+                candidates.push(field.clone());
+                log::debug!(
+                    "Phase 2: Force-injected {} (identity field for {})",
+                    field_name,
+                    primary
+                );
             }
         }
 
@@ -2845,16 +2865,15 @@ Resource selection guidance:
                 let match_score = term_matches.len() + if has_name_match { 2 } else { 0 };
 
                 // Only add fields with reasonable match scores
-                if (match_score >= 2 || has_name_match)
-                    && seen.insert(field_name.clone()) {
-                        log::trace!(
-                            "Phase 2: Keyword match '{}' (score={}, terms={:?})",
-                            field_name,
-                            match_score,
-                            term_matches
-                        );
-                        matches.push(field.clone());
-                    }
+                if (match_score >= 2 || has_name_match) && seen.insert(field_name.clone()) {
+                    log::trace!(
+                        "Phase 2: Keyword match '{}' (score={}, terms={:?})",
+                        field_name,
+                        match_score,
+                        term_matches
+                    );
+                    matches.push(field.clone());
+                }
             }
         }
 
@@ -3042,7 +3061,9 @@ Resource selection guidance:
         let (this_christmas_start, this_christmas_end) = dates.this_christmas;
 
         let metric_terminology = self.domain_knowledge.section("Metric Terminology");
-        let numeric_monetary = self.domain_knowledge.section("Numeric and Monetary Conversion");
+        let numeric_monetary = self
+            .domain_knowledge
+            .section("Numeric and Monetary Conversion");
         let monetary_extraction = self.domain_knowledge.section("Monetary Value Extraction");
         let date_range_handling = self.domain_knowledge.section("Date Range Handling");
         let query_best_practices = self.domain_knowledge.section("Query Best Practices");
@@ -3309,21 +3330,19 @@ Respond ONLY with valid JSON:
             let needs_micros = ff.field_name.ends_with("_micros")
                 || ff.field_name.contains("cost_per_")
                 || ff.field_name.contains("amount_micros");
-            if needs_micros {
-                if let Some(converted) = try_convert_to_micros(&ff.value) {
-                    log::debug!(
-                        "Phase 3: Micros conversion for '{}': '{}' → '{}'",
-                        ff.field_name,
-                        ff.value,
-                        converted
-                    );
-                    ff.value = converted;
-                }
+            if needs_micros && let Some(converted) = try_convert_to_micros(&ff.value) {
+                log::debug!(
+                    "Phase 3: Micros conversion for '{}': '{}' → '{}'",
+                    ff.field_name,
+                    ff.value,
+                    converted
+                );
+                ff.value = converted;
             }
         }
 
         // Validation: detect zero thresholds when query contains monetary patterns
-        validate_monetary_thresholds(&mut filter_fields, &user_query);
+        validate_monetary_thresholds(&mut filter_fields, user_query);
 
         let order_by_fields: Vec<(String, String)> = parsed["order_by_fields"]
             .as_array()
@@ -3361,7 +3380,10 @@ Respond ONLY with valid JSON:
             .map(|s| s.to_string())
             .unwrap_or_default();
 
-        let limit = parsed.get("limit").and_then(|v| v.as_u64()).map(|n| n as u32);
+        let limit = parsed
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32);
 
         Ok(FieldSelectionResult {
             select_fields: final_select_fields,
@@ -3587,7 +3609,9 @@ Respond ONLY with valid JSON:
         }
 
         // Limit detection: LLM-provided limit takes priority, detect_limit as fallback
-        let limit = field_selection.limit.or_else(|| self.detect_limit(user_query));
+        let limit = field_selection
+            .limit
+            .or_else(|| self.detect_limit(user_query));
 
         // Implicit defaults (if enabled)
         if self.pipeline_config.add_defaults {
@@ -3940,7 +3964,7 @@ fn try_convert_to_micros(value: &str) -> Option<String> {
 }
 
 /// Validation: Detect zero thresholds when query contains monetary patterns
-fn validate_monetary_thresholds(filter_fields: &mut Vec<FilterField>, user_query: &str) {
+fn validate_monetary_thresholds(filter_fields: &mut [FilterField], user_query: &str) {
     lazy_static::lazy_static! {
         static ref MONETARY_PATTERN: regex::Regex = regex::Regex::new(
             r"(?i)(?:cost|cpa|spend|budget|amount|value|revenue).*?\$?\d+(?:\.\d+)?(?:\s*[KkMmBb])?|\$\d+(?:\.\d+)?(?:\s*[KkMmBb])?"
@@ -3963,7 +3987,8 @@ fn validate_monetary_thresholds(filter_fields: &mut Vec<FilterField>, user_query
             if let Some(extracted) = extract_threshold_from_query(user_query, &ff.field_name) {
                 log::info!(
                     "Phase 3: Correcting zero threshold for '{}' to '{}'",
-                    ff.field_name, extracted
+                    ff.field_name,
+                    extracted
                 );
                 ff.value = extracted;
             }
@@ -4246,7 +4271,10 @@ mod tests {
 
     #[test]
     fn test_try_convert_to_micros_with_comma() {
-        assert_eq!(try_convert_to_micros("1,000"), Some("1000000000".to_string()));
+        assert_eq!(
+            try_convert_to_micros("1,000"),
+            Some("1000000000".to_string())
+        );
     }
 
     #[test]
@@ -4551,7 +4579,10 @@ mod tests {
             .map(|s| s.to_string())
             .unwrap_or_default();
 
-        let limit = parsed.get("limit").and_then(|v| v.as_u64()).map(|n| n as u32);
+        let limit = parsed
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32);
 
         Some(FieldSelectionResult {
             select_fields,
@@ -4742,7 +4773,10 @@ mod tests {
             Some("200000000".to_string())
         );
         assert_eq!(
-            extract_threshold_from_query("cost per conversion over $150", "metrics.cost_per_conversion"),
+            extract_threshold_from_query(
+                "cost per conversion over $150",
+                "metrics.cost_per_conversion"
+            ),
             Some("150000000".to_string())
         );
         assert_eq!(
@@ -4794,13 +4828,11 @@ mod tests {
 
         let user_query = "campaigns with no conversions";
 
-        let mut filter_fields = vec![
-            FilterField {
-                field_name: "metrics.conversions".to_string(),
-                operator: "=".to_string(),
-                value: "0".to_string(),
-            },
-        ];
+        let mut filter_fields = vec![FilterField {
+            field_name: "metrics.conversions".to_string(),
+            operator: "=".to_string(),
+            value: "0".to_string(),
+        }];
 
         validate_monetary_thresholds(&mut filter_fields, user_query);
 
@@ -4851,10 +4883,7 @@ mod tests {
 
     #[test]
     fn test_normalize_in_value_empty_list() {
-        assert_eq!(
-            MultiStepRAGAgent::normalize_in_value("[]"),
-            "()"
-        );
+        assert_eq!(MultiStepRAGAgent::normalize_in_value("[]"), "()");
     }
 
     #[test]
@@ -4908,10 +4937,7 @@ mod tests {
 
     #[test]
     fn test_normalize_string_value_empty_quotes() {
-        assert_eq!(
-            MultiStepRAGAgent::normalize_string_value("''"),
-            ""
-        );
+        assert_eq!(MultiStepRAGAgent::normalize_string_value("''"), "");
     }
 
     // Helper: Check if a resource requires non-empty selectable_with

--- a/crates/mcc-gaql-gen/src/scraper.rs
+++ b/crates/mcc-gaql-gen/src/scraper.rs
@@ -148,7 +148,6 @@ impl ScrapedDocs {
             15,
         )?;
 
-
         let mut docs: HashMap<String, ScrapedFieldDoc> = HashMap::new();
         let mut resources_scraped = 0usize;
         let mut resources_skipped = 0usize;

--- a/crates/mcc-gaql/src/config.rs
+++ b/crates/mcc-gaql/src/config.rs
@@ -395,13 +395,25 @@ pub fn display_config(profile_name: Option<&str>) -> anyhow::Result<()> {
 
     // Config directory files
     show_path_status("Config directory", &mcc_gaql_common::paths::config_dir());
-    show_path_status("Query cookbook", &mcc_gaql_common::paths::query_cookbook_path());
-    show_path_status("Domain knowledge", &mcc_gaql_common::paths::domain_knowledge_path());
+    show_path_status(
+        "Query cookbook",
+        &mcc_gaql_common::paths::query_cookbook_path(),
+    );
+    show_path_status(
+        "Domain knowledge",
+        &mcc_gaql_common::paths::domain_knowledge_path(),
+    );
 
     // Cache directory files
     show_path_status("Cache directory", &mcc_gaql_common::paths::cache_dir());
-    show_path_status("Field metadata", &mcc_gaql_common::paths::field_metadata_cache_path());
-    show_path_status("Field metadata (enriched)", &mcc_gaql_common::paths::field_metadata_enriched_path());
+    show_path_status(
+        "Field metadata",
+        &mcc_gaql_common::paths::field_metadata_cache_path(),
+    );
+    show_path_status(
+        "Field metadata (enriched)",
+        &mcc_gaql_common::paths::field_metadata_enriched_path(),
+    );
     show_path_status("Proto docs", &mcc_gaql_common::paths::proto_docs_path());
     show_path_status("LanceDB", &mcc_gaql_common::paths::lancedb_path());
 

--- a/crates/mcc-gaql/src/field_metadata.rs
+++ b/crates/mcc-gaql/src/field_metadata.rs
@@ -267,8 +267,11 @@ fn build_resource_metadata_from_fields(
 
         key_metrics.sort();
 
-        let identity_fields =
-            mcc_gaql_common::field_metadata::compute_identity_fields(resource_name, fields, &selectable_with);
+        let identity_fields = mcc_gaql_common::field_metadata::compute_identity_fields(
+            resource_name,
+            fields,
+            &selectable_with,
+        );
 
         resource_metadata.insert(
             resource_name.clone(),

--- a/crates/mcc-gaql/src/setup.rs
+++ b/crates/mcc-gaql/src/setup.rs
@@ -164,7 +164,9 @@ pub fn run_wizard() -> Result<()> {
     let has_runtime_secret = std::env::var("MCC_GAQL_EMBED_CLIENT_SECRET").is_ok();
 
     if has_runtime_secret {
-        println!("  1. OAuth2 credentials found in MCC_GAQL_EMBED_CLIENT_SECRET environment variable");
+        println!(
+            "  1. OAuth2 credentials found in MCC_GAQL_EMBED_CLIENT_SECRET environment variable"
+        );
     } else {
         println!(
             "  1. Place your OAuth2 credentials in: {:?}",

--- a/resources/domain_knowledge.md
+++ b/resources/domain_knowledge.md
@@ -57,10 +57,20 @@
   - User explicitly asks for portfolio-level bidding strategy performance
   - User wants to compare different bidding strategies to each other (not campaigns)
   - User asks "how is my target CPA strategy performing overall"
-- For location-level performance data ("top locations", "best performing regions", "geo performance"):
-  Use `location_view` with `campaign_criterion` fields. Each row represents a UNIQUE COMBINATION of campaign + geo target, so it naturally supports "top locations per campaign" analysis.
+- For geographic performance with city/state/region SEGMENTATION (segments.geo_target_city, segments.geo_target_state, etc.):
+  **TRIGGER PATTERNS requiring geographic_view or user_location_view:**
+  - User mentions "city segmentation", "breakdown by city", "by state", "by region", "by metro"
+  - User asks for "cities with highest X", "top cities", "performance by city"
+  - User asks "where are users located", "geographic distribution", "geo breakdown"
+  
+  Use `geographic_view` or `user_location_view`. These resources support geo_target_* segments for granular geographic breakdowns.
+  
+  **CRITICAL: Do NOT use `location_view` for city/state segmentation queries** - `location_view` does NOT support geo_target_* segments. Check the [Segments: ...] annotation - only resources showing "geo_target_*" can do city/state breakdowns.
+  
+- For targeted location performance data ("top targeted locations", "performance of geo targets"):
+  Use `location_view` with `campaign_criterion` fields. Each row represents a UNIQUE COMBINATION of campaign + geo target criterion.
   The `campaign_criterion.location.geo_target_constant` field provides the geo target ID.
-  Do NOT use `campaign` with geo segments - that gives campaign-level data only, not individual location performance.
+  Do NOT use `campaign` alone - that gives campaign-level data only, not individual location target performance.
 - For impression share metrics (search impression share, budget lost impression share, etc.),
   use the `campaign` resource. Specialized views like `performance_max_placement_view` are for
   placement-level data and do NOT expose impression share metrics.

--- a/specs/show_all_selectable_via_metadata_cmd.md
+++ b/specs/show_all_selectable_via_metadata_cmd.md
@@ -1,0 +1,160 @@
+# Plan: Add Selectable Fields Display to Metadata Command
+
+## Context
+
+**User Request**: When running `mcc-gaql-gen metadata geographic_view`, show all the fields from `selectable_with` that can be used with this resource, organized into sections: SEGMENTS, METRICS, and OTHER (auto-joined fields).
+
+**Current Behavior**: The metadata command shows only the resource's own fields (attributes, metrics, segments that belong to the resource itself), but NOT the fields from `selectable_with` that can be queried together with the resource.
+
+**Goal**: Display new sections showing selectable fields from `ResourceMetadata.selectable_with`, categorized as:
+- **SELECTABLE SEGMENTS**: Fields starting with `segments.*`
+- **SELECTABLE METRICS**: Fields starting with `metrics.*`  
+- **SELECTABLE OTHER**: Remaining fields (auto-joined from other resources like `customer.*`, `campaign.*`)
+
+## Implementation
+
+### File to Modify
+
+**`crates/mcc-gaql-gen/src/formatter.rs`**
+
+### Changes
+
+#### 1. Add helper function to categorize selectable_with fields
+
+```rust
+/// Categorize selectable_with fields into segments, metrics, and other
+fn categorize_selectable_with(selectable_with: &[String]) -> (Vec<&str>, Vec<&str>, Vec<&str>) {
+    let mut segments = Vec::new();
+    let mut metrics = Vec::new();
+    let mut other = Vec::new();
+    
+    for field in selectable_with {
+        if field.starts_with("segments.") {
+            segments.push(field.as_str());
+        } else if field.starts_with("metrics.") {
+            metrics.push(field.as_str());
+        } else {
+            other.push(field.as_str());
+        }
+    }
+    
+    segments.sort();
+    metrics.sort();
+    other.sort();
+    
+    (segments, metrics, other)
+}
+```
+
+#### 2. Update `format_full()` for `QueryResult::Resource` (after line 696)
+
+After the resource's own fields display, add:
+
+```rust
+// Show selectable_with fields categorized
+let (selectable_segments, selectable_metrics, selectable_other) = 
+    categorize_selectable_with(&metadata.selectable_with);
+
+if !selectable_segments.is_empty() || !selectable_metrics.is_empty() || !selectable_other.is_empty() {
+    output.push_str("\n--- SELECTABLE WITH (auto-joined fields) ---\n\n");
+    
+    if !selectable_segments.is_empty() {
+        output.push_str(&format!("### SELECTABLE SEGMENTS ({})\n", selectable_segments.len()));
+        for seg in &selectable_segments {
+            output.push_str(&format!("  - {}\n", seg));
+        }
+        output.push('\n');
+    }
+    
+    if !selectable_metrics.is_empty() {
+        output.push_str(&format!("### SELECTABLE METRICS ({})\n", selectable_metrics.len()));
+        for metric in &selectable_metrics {
+            output.push_str(&format!("  - {}\n", metric));
+        }
+        output.push('\n');
+    }
+    
+    if !selectable_other.is_empty() {
+        output.push_str(&format!("### SELECTABLE OTHER ({})\n", selectable_other.len()));
+        for field in &selectable_other {
+            output.push_str(&format!("  - {}\n", field));
+        }
+    }
+}
+```
+
+#### 3. Update `format_llm()` for `QueryResult::Resource` (after line 536)
+
+Add compact version:
+
+```rust
+// Show selectable_with counts
+let (selectable_segments, selectable_metrics, selectable_other) = 
+    categorize_selectable_with(&metadata.selectable_with);
+
+if !selectable_segments.is_empty() {
+    output.push_str(&format!(
+        "Selectable segments ({}): {}\n",
+        selectable_segments.len(),
+        selectable_segments.iter().take(10).cloned().collect::<Vec<_>>().join(", ")
+    ));
+    if selectable_segments.len() > 10 {
+        output.push_str(&format!("  ... and {} more\n", selectable_segments.len() - 10));
+    }
+}
+
+if !selectable_metrics.is_empty() {
+    output.push_str(&format!(
+        "Selectable metrics ({}): {}\n",
+        selectable_metrics.len(),
+        selectable_metrics.iter().take(10).cloned().collect::<Vec<_>>().join(", ")
+    ));
+    if selectable_metrics.len() > 10 {
+        output.push_str(&format!("  ... and {} more\n", selectable_metrics.len() - 10));
+    }
+}
+```
+
+## Verification
+
+```bash
+cargo build -p mcc-gaql-gen
+mcc-gaql-gen metadata geographic_view --format full
+```
+
+Expected output should include:
+```
+--- SELECTABLE WITH (auto-joined fields) ---
+
+### SELECTABLE SEGMENTS (25)
+  - segments.ad_network_type
+  - segments.conversion_action
+  - segments.date
+  - segments.device
+  - segments.geo_target_city
+  - segments.geo_target_country
+  - segments.geo_target_metro
+  - segments.geo_target_region
+  ...
+
+### SELECTABLE METRICS (33)
+  - metrics.all_conversions
+  - metrics.clicks
+  - metrics.conversions
+  - metrics.cost_micros
+  - metrics.impressions
+  ...
+
+### SELECTABLE OTHER (8)
+  - customer.currency_code
+  - customer.descriptive_name
+  - customer.id
+  ...
+```
+
+Compare with:
+```bash
+mcc-gaql-gen metadata location_view --format full
+```
+
+Which should show different segments (no `segments.geo_target_*` fields).


### PR DESCRIPTION
## Summary

This PR improves RAG resource selection and metadata display with two key enhancements:

1. **Phase 1 Resource Selection:** Display segment category summaries to help LLM choose resources based on segment support
2. **Metadata Command:** Show selectable fields categorized by type (segments, metrics, other) + fix all clippy warnings

## Problem Statement

**Resource Selection Issue:** When users asked for "city segmentation" or "performance by city/state", the LLM selected `location_view` (which doesn't support geo segments) instead of `geographic_view` or `user_location_view` (which do). Phase 2 then correctly filtered out `segments.geo_target_city` because it's incompatible with `location_view`.

**Metadata Visibility Issue:** The metadata command showed a resource's own fields but didn't display which fields from other resources can be auto-joined (via `selectable_with`), making it hard to understand query capabilities.

## Changes

### 1. RAG Phase 1: Segment Category Display (commit eb514bd)

#### Code Changes (crates/mcc-gaql-gen/src/rag.rs)
- **New method:** `summarize_resource_segments()` - categorizes segment support into compact labels
- **Modified:** `build_categorized_resource_list()` - appends `[Segments: ...]` to descriptions
- **Modified:** Phase 1 resource sample - includes segment summaries for the 5 sampled resources
- **Smart truncation:** Expanded to 200 chars with logic to preserve full segment annotations

#### Domain Knowledge (resources/domain_knowledge.md)
- Added explicit geo segmentation guidance with trigger patterns
- Distinguishes `geographic_view`/`user_location_view` (supports geo segments) from `location_view` (targeted locations only)

#### Examples

Before:
```
- geographic_view: It aggregates performance metrics by country for user location...
- location_view: A location_view summarizes campaign performance by location criteria...
```

After:
```
- geographic_view: It aggregates performance metrics by country... [Segments: geo_target_* (city/state/region), date/time, device, conversion, ad_network]
- location_view: A location_view summarizes campaign performance... [Segments: date/time, conversion]
```

#### Segment Categories

- `geo_target_* (city/state/region)` - geographic segmentation
- `hotel_*` - hotel-specific segments  
- `product_*` - product-specific segments
- `date/time` - temporal segments (date, day_of_week, hour, etc.)
- `device` - device type
- `conversion` - conversion-related segments
- `ad_network` - ad network type

#### Test Results

Query: "show performance breakdown by city"
- **Before:** Selected `location_view` → Phase 2 filtered out `segments.geo_target_city`
- **After:** Selects `geographic_view` → Phase 2 includes `segments.geo_target_city` ✓

Query: "use city segmentation to get cities with highest clicks"  
- **After:** Selects `geographic_view` → includes `segments.geo_target_city` ✓

---

### 2. Metadata Command: Selectable Fields Display (commit 55bf721)

#### New Features
- **Categorized display** of selectable fields from `ResourceMetadata.selectable_with`
  - `SELECTABLE SEGMENTS` - fields starting with `segments.*`
  - `SELECTABLE METRICS` - fields starting with `metrics.*`  
  - `SELECTABLE OTHER` - remaining auto-joinable fields (e.g., `customer.*`, `campaign.*`)
- **Full format** (`--format full`): Complete sorted lists with counts
- **LLM format** (`--format llm`): First 10 fields + "... and X more" indicator

#### Example Output

```bash
$ mcc-gaql-gen metadata geographic_view --format full
```

Shows new section:
```
--- SELECTABLE WITH (auto-joined fields) ---

### SELECTABLE SEGMENTS (25)
  - segments.ad_network_type
  - segments.conversion_action
  - segments.date
  - segments.device
  - segments.geo_target_city
  - segments.geo_target_country
  ...

### SELECTABLE METRICS (35)
  - metrics.all_conversions
  - metrics.clicks
  - metrics.conversions
  - metrics.cost_micros
  ...

### SELECTABLE OTHER (3)
  - ad_group
  - campaign
  - customer
```

LLM format shows compact summary:
```
Selectable segments (25): segments.ad_network_type, segments.ad_sub_network_type, ... (first 10)
  ... and 15 more
Selectable metrics (35): metrics.absolute_top_impression_percentage, ... (first 10)
  ... and 25 more
Selectable other (3): ad_group, campaign, customer
```

#### Code Quality: Clippy Fixes (15 warnings → 0)

All clippy warnings eliminated across the workspace:

**mcc-gaql-common:**
- Collapsed nested if statement using let chains (field_metadata.rs:559)
- Converted `loop` to `while let` loop (field_metadata.rs:840)
- Removed needless `Ok(...)?)` wrapper (http_client.rs:19)

**mcc-gaql-gen:**
- Collapsed nested if statement using let chains (bundle.rs:151)
- Collapsed nested if statement using let chains (rag.rs:1476)
- Fixed `format!()` inside `format!()` by extracting to variable (rag.rs:2145)
- Collapsed 5 nested if statements using let chains (rag.rs:2681-2766)
- Collapsed nested if statement using let chains (rag.rs:3337)
- Fixed needless borrow by removing `&` (rag.rs:3351)
- Changed `&mut Vec<FilterField>` to `&mut [FilterField]` (rag.rs:3973)
- Refactored `cmd_generate` with `GenerateParams` struct to reduce arguments from 9 to 1 (main.rs:876)
- Used `strip_prefix()` instead of manual string slicing (main.rs:987)

#### Verification
✅ `cargo clippy --workspace -- -D warnings` passes with zero warnings  
✅ `cargo build --workspace` succeeds  
✅ All functionality preserved and tested  
✅ Backward compatible

## Files Changed

**14 files changed, 868 insertions(+), 437 deletions(-)**

Core changes:
- `crates/mcc-gaql-gen/src/rag.rs` - Segment categorization + clippy fixes
- `crates/mcc-gaql-gen/src/formatter.rs` - Selectable fields display
- `crates/mcc-gaql-gen/src/main.rs` - GenerateParams refactor
- `crates/mcc-gaql-common/src/field_metadata.rs` - Clippy fixes
- `resources/domain_knowledge.md` - Geo segmentation guidance
- `specs/show_all_selectable_via_metadata_cmd.md` - Feature specification

## Testing

Both features tested and verified:

1. **Segment categories:** Correctly guides LLM to choose `geographic_view` for city/state queries
2. **Selectable fields:** Display works for both `--format full` and `--format llm`
3. **Clippy:** All warnings eliminated, strict mode passes
4. **Build:** All crates compile without errors

## Impact

- **Improved accuracy:** LLM now selects correct resources based on segment support
- **Better visibility:** Users can see all queryable fields for each resource
- **Code quality:** Cleaner, more maintainable code following Rust best practices
- **No breaking changes:** All changes are backward compatible
